### PR TITLE
Update design-tool skills and QC, add Mosaic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "protein-design-skills",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Claude Code skills for computational protein design - backbone generation, sequence design, structure prediction, and experimental validation",
   "owner": {
     "name": "tudor@adaptyv",
@@ -9,12 +9,13 @@
   "plugins": [
     {
       "name": "adaptyv",
-      "description": "All 21 protein design skills",
+      "description": "All 22 protein design skills",
       "source": "./",
       "skills": [
         "./skills/boltzgen",
         "./skills/bindcraft",
         "./skills/rfdiffusion",
+        "./skills/mosaic",
         "./skills/proteinmpnn",
         "./skills/ligandmpnn",
         "./skills/solublempnn",
@@ -37,12 +38,13 @@
     },
     {
       "name": "design-tools",
-      "description": "Core protein design methods (BoltzGen, BindCraft, RFdiffusion, etc.)",
+      "description": "Core protein design methods (BoltzGen, BindCraft, RFdiffusion, Mosaic, etc.)",
       "source": "./",
       "skills": [
         "./skills/boltzgen",
         "./skills/bindcraft",
         "./skills/rfdiffusion",
+        "./skills/mosaic",
         "./skills/proteinmpnn",
         "./skills/ligandmpnn",
         "./skills/solublempnn",
@@ -110,6 +112,12 @@
       "skills": ["./skills/rfdiffusion"]
     },
     {
+      "name": "mosaic",
+      "description": "Multi-objective, gradient-based binder design using Mosaic",
+      "source": "./",
+      "skills": ["./skills/mosaic"]
+    },
+    {
       "name": "proteinmpnn",
       "description": "Design protein sequences using ProteinMPNN inverse folding",
       "source": "./",
@@ -147,7 +155,7 @@
     },
     {
       "name": "esm",
-      "description": "ESM2 protein language model for embeddings and sequence scoring",
+      "description": "ESM protein language models (ESM C, ESMFold2, ESM2) for embeddings, scoring, structure prediction, and binder design",
       "source": "./",
       "skills": ["./skills/esm"]
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,18 +9,20 @@
   "plugins": [
     {
       "name": "adaptyv",
-      "description": "All 22 protein design skills",
+      "description": "All 24 protein design skills",
       "source": "./",
       "skills": [
         "./skills/boltzgen",
         "./skills/bindcraft",
         "./skills/rfdiffusion",
         "./skills/mosaic",
+        "./skills/germinal",
         "./skills/proteinmpnn",
         "./skills/ligandmpnn",
         "./skills/solublempnn",
         "./skills/chai",
         "./skills/boltz",
+        "./skills/protenix",
         "./skills/alphafold",
         "./skills/esm",
         "./skills/protein-qc",
@@ -38,18 +40,20 @@
     },
     {
       "name": "design-tools",
-      "description": "Core protein design methods (BoltzGen, BindCraft, RFdiffusion, Mosaic, etc.)",
+      "description": "Core protein design methods (BoltzGen, BindCraft, RFdiffusion, Mosaic, Germinal, etc.)",
       "source": "./",
       "skills": [
         "./skills/boltzgen",
         "./skills/bindcraft",
         "./skills/rfdiffusion",
         "./skills/mosaic",
+        "./skills/germinal",
         "./skills/proteinmpnn",
         "./skills/ligandmpnn",
         "./skills/solublempnn",
         "./skills/chai",
         "./skills/boltz",
+        "./skills/protenix",
         "./skills/alphafold",
         "./skills/esm"
       ]
@@ -116,6 +120,18 @@
       "description": "Multi-objective, gradient-based binder design using Mosaic",
       "source": "./",
       "skills": ["./skills/mosaic"]
+    },
+    {
+      "name": "germinal",
+      "description": "De novo antibody and nanobody (VHH) design using Germinal",
+      "source": "./",
+      "skills": ["./skills/germinal"]
+    },
+    {
+      "name": "protenix",
+      "description": "Structure prediction using Protenix, an open AlphaFold3 reproduction",
+      "source": "./",
+      "skills": ["./skills/protenix"]
     },
     {
       "name": "proteinmpnn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,28 @@
 
 ### Added
 - `mosaic` skill: multi-objective, gradient-based binder design (Escalante Bio)
+- `germinal` skill: de novo antibody and nanobody (VHH) design via biomodals
+- `protenix` skill: open AlphaFold3-class structure prediction via biomodals
 - `esm` skill now covers ESM C and ESMFold2, including binder design by inverting
   ESMFold2; ESM2 kept as legacy
 - protein-qc: SaProtΔG stability prediction, benchmark-backed ipSAE_min ranking with
   thresholds, interface BUNS and ContactMolecularSurface, sequence-liability scan
 
 ### Changed
+- Binder design is framed by target type and hit-rate rather than a single recommended
+  pipeline; adds a proteinbase Nipah head-to-head hit-rate table, features Mosaic as the
+  top competition performer, and keeps BoltzGen as the cheap turnkey default with a
+  compute-versus-hit-rate note
 - Boltz skill documents Boltz-2 as the default, including the affinity-prediction module
-- Binder design no longer frames BoltzGen as the single recommended pipeline; tools are
-  chosen by target type and compute
 - Fixed dangling links: skills now point to `getting-started.md` for setup
-- Removed the dangling Germinal skill reference (antibody/nanobody tools noted as external)
+
+### Fixed
+- Corrected biomodals references: ProteinMPNN runs via `modal_ligandmpnn.py`, ESM2 via
+  `modal_esm2_predict_masked.py`, folding via `modal_esmfold2.py`, and ColabFold steps
+  use `modal_alphafold.py`
+- RFdiffusion is documented as running from the official RosettaCommons repo, since it
+  is not packaged in biomodals
+- Corrected the Mosaic `build_multisample_loss` usage and the ESMFold2 / ESM C API calls
 
 ## [2.0.0] - 2026-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@
 - RFdiffusion is documented as running from the official RosettaCommons repo, since it
   is not packaged in biomodals
 - Corrected the Mosaic `build_multisample_loss` usage and the ESMFold2 / ESM C API calls
+- Fact-check pass across all skills: corrected biomodals CLI flags (`--input-pdb`,
+  `--input-fasta`, `--input-faa`/`--out-dir`, LigandMPNN `--params-str`), BindCraft and
+  BoltzGen run commands, RFdiffusion install/weights/hydra quoting, SolubleMPNN
+  `--use_soluble_model`, Foldseek `--max-seqs` default and database sizes, ipSAE
+  attribution, SaProtΔG domain range, the inverted BLI koff red flag, and references to
+  non-existent `colabfold`/`colabdesign` skills
+- Binder-tool default is framed by cost and effort to a binder, since hit-rate is
+  target-dependent for every method
+
+### Added (follow-up)
+- Protenix-v2 noted for antibody-antigen complexes (`--model-name protenix-v2`)
 
 ## [2.0.0] - 2026-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 ### Added (follow-up)
 - Protenix-v2 noted for antibody-antigen complexes (`--model-name protenix-v2`)
+- Measured compute cost per accepted design (averaged across 7 internal benchmark
+  targets) added to binder-design and the relevant tool skills
 
 ## [2.0.0] - 2026-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.1.0] - 2026-06-11
+
+### Added
+- `mosaic` skill: multi-objective, gradient-based binder design (Escalante Bio)
+- `esm` skill now covers ESM C and ESMFold2, including binder design by inverting
+  ESMFold2; ESM2 kept as legacy
+- protein-qc: SaProtΔG stability prediction, benchmark-backed ipSAE_min ranking with
+  thresholds, interface BUNS and ContactMolecularSurface, sequence-liability scan
+
+### Changed
+- Boltz skill documents Boltz-2 as the default, including the affinity-prediction module
+- Binder design no longer frames BoltzGen as the single recommended pipeline; tools are
+  chosen by target type and compute
+- Fixed dangling links: skills now point to `getting-started.md` for setup
+- Removed the dangling Germinal skill reference (antibody/nanobody tools noted as external)
+
 ## [2.0.0] - 2026-01-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>21 Claude Code skills for computational protein design</strong>
+  <strong>22 Claude Code skills for computational protein design</strong>
 </p>
 
 <p align="center">
@@ -39,7 +39,7 @@
   <img src="assets/skill_categories.svg" width="550" alt="Skill categories">
 </p>
 
-→ [View all 21 skills](docs/skills.md)
+→ [View all 22 skills](docs/skills.md)
 
 ---
 
@@ -57,7 +57,8 @@
 
 > "Design a binder for PDB 1ALU"
 
-Claude will automatically use the right skills (BoltzGen → Chai → QC).
+Claude will pick the right skills for the target (for example BoltzGen → Chai → QC,
+or RFdiffusion → ProteinMPNN → Chai → QC).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>22 Claude Code skills for computational protein design</strong>
+  <strong>24 Claude Code skills for computational protein design</strong>
 </p>
 
 <p align="center">
@@ -39,7 +39,7 @@
   <img src="assets/skill_categories.svg" width="550" alt="Skill categories">
 </p>
 
-→ [View all 22 skills](docs/skills.md)
+→ [View all 24 skills](docs/skills.md)
 
 ---
 

--- a/docs/compute-setup.md
+++ b/docs/compute-setup.md
@@ -100,6 +100,6 @@ First run downloads model weights. Subsequent runs are faster.
 
 ## See also
 
-- [Skills](skills.md) - All 21 skills
+- [Skills](skills.md) - All 22 skills
 - [Getting started](getting-started.md) - Setup guide
 - [Standard pipeline](standard-pipeline.md) - Full workflow

--- a/docs/compute-setup.md
+++ b/docs/compute-setup.md
@@ -60,8 +60,8 @@ For local GPU execution, each tool requires specific setup. See individual skill
 
 Set GPU in Modal:
 ```bash
-GPU=A10G uvx modal run modal_rfdiffusion.py ...
-GPU=L40S uvx modal run modal_boltzgen.py ...
+GPU=L40S uv run --with modal modal run modal_boltzgen.py ...
+MODAL_GPU=A100 uv run --with modal modal run modal_esmfold2.py ...
 ```
 
 ## Tool-specific requirements
@@ -70,7 +70,7 @@ GPU=L40S uvx modal run modal_boltzgen.py ...
 |------|-------------|-------------|------------------|
 | BoltzGen | L40S (48GB) | A100 | modal_boltzgen.py |
 | BindCraft | L40S (48GB) | L40S | modal_bindcraft.py |
-| RFdiffusion | A10G (24GB) | A10G | modal_rfdiffusion.py |
+| RFdiffusion | A10G (24GB) | A10G | not in biomodals; official repo |
 | ProteinMPNN | T4 (16GB) | T4 | modal_ligandmpnn.py |
 | LigandMPNN | T4 (16GB) | T4 | modal_ligandmpnn.py |
 | Chai | A10G (24GB) | A100 | modal_chai1.py |
@@ -100,6 +100,6 @@ First run downloads model weights. Subsequent runs are faster.
 
 ## See also
 
-- [Skills](skills.md) - All 22 skills
+- [Skills](skills.md) - All 24 skills
 - [Getting started](getting-started.md) - Setup guide
 - [Standard pipeline](standard-pipeline.md) - Full workflow

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ git clone https://github.com/hgbrian/biomodals
 cd biomodals
 ```
 
-Verify: You should see files like `modal_boltzgen.py`, `modal_rfdiffusion.py`
+Verify: You should see files like `modal_boltzgen.py`, `modal_chai1.py`, `modal_esmfold2.py`
 
 ## Step 4: Test your setup
 
@@ -101,8 +101,8 @@ Expected output:
 # BoltzGen (all-atom, single-step)
 uvx modal run modal_boltzgen.py --target target.pdb --num-designs 50
 
-# RFdiffusion (backbone generation)
-uvx modal run modal_rfdiffusion.py --input-pdb target.pdb --contigs "A1-150/0 70-100" --num-designs 100
+# RFdiffusion (backbone generation; official repo, not biomodals)
+python run_inference.py inference.input_pdb=target.pdb contigmap.contigs=[A1-150/0 70-100] inference.num_designs=100
 
 # BindCraft (end-to-end)
 uvx modal run modal_bindcraft.py --target-pdb target.pdb --num-designs 50
@@ -127,9 +127,9 @@ uvx modal run modal_boltz.py --fasta-path designs.fasta --output-dir predictions
 
 Set GPU with environment variable:
 ```bash
-GPU=A10G uvx modal run modal_rfdiffusion.py ...
 GPU=L40S uvx modal run modal_boltzgen.py ...
 GPU=A100 uvx modal run modal_chai1.py ...
+MODAL_GPU=A100 uvx modal run modal_esmfold2.py ...
 ```
 
 | GPU | VRAM | Best For |
@@ -171,6 +171,6 @@ First run downloads model weights (~5-10 min). Subsequent runs are faster.
 
 ## See also
 
-- [Skills](skills.md) - All 22 skills
+- [Skills](skills.md) - All 24 skills
 - [Standard pipeline](standard-pipeline.md) - Full workflow details
 - [Compute setup](compute-setup.md) - Modal vs local setup

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,13 +64,12 @@ cd biomodals
 uvx modal run modal_boltzgen.py --help
 ```
 
-Expected output:
+Expected output (key options):
 ```
-Usage: modal_boltzgen.py [OPTIONS]
-Options:
-  --target TEXT          Target PDB file
-  --num-designs INTEGER  Number of designs to generate
-  ...
+modal_boltzgen.py
+  --input-yaml TEXT     Design specification YAML (required)
+  --protocol TEXT       protein-anything (default), peptide-anything, ...
+  --num-designs INTEGER Number of designs to generate
 ```
 
 ## Step 5: Run your first design
@@ -81,46 +80,38 @@ curl -o target.pdb https://files.rcsb.org/download/1ALU.pdb
 ```
 
 ### Run BoltzGen
+BoltzGen takes a YAML design spec (see the `boltzgen` skill for the format):
 ```bash
-uvx modal run modal_boltzgen.py --target target.pdb --num-designs 5
-```
-
-Expected output:
-```
-[INFO] Loading BoltzGen model...
-[INFO] Generating 5 designs...
-[INFO] Design 1/5 completed
-...
-[INFO] Saved to output/
+uvx modal run modal_boltzgen.py --input-yaml binder.yaml --protocol protein-anything --num-designs 5
 ```
 
 ## Quick reference: common commands
 
 ### Design
 ```bash
-# BoltzGen (all-atom, single-step)
-uvx modal run modal_boltzgen.py --target target.pdb --num-designs 50
+# BoltzGen (all-atom, single-step); needs a YAML design spec
+uvx modal run modal_boltzgen.py --input-yaml binder.yaml --protocol protein-anything --num-designs 50
 
 # RFdiffusion (backbone generation; official repo, not biomodals)
-python run_inference.py inference.input_pdb=target.pdb contigmap.contigs=[A1-150/0 70-100] inference.num_designs=100
+python run_inference.py inference.input_pdb=target.pdb 'contigmap.contigs=[A1-150/0 70-100]' inference.num_designs=100
 
 # BindCraft (end-to-end)
-uvx modal run modal_bindcraft.py --target-pdb target.pdb --num-designs 50
+uvx modal run modal_bindcraft.py --input-pdb target.pdb --lengths "70,100" --number-of-final-designs 50
 ```
 
 ### Sequence design
 ```bash
-# LigandMPNN/ProteinMPNN
-uvx modal run modal_ligandmpnn.py --pdb-path backbone.pdb --num-seq-per-target 8
+# LigandMPNN (also runs ProteinMPNN weights); extra args go in --params-str
+uvx modal run modal_ligandmpnn.py --input-pdb backbone.pdb --params-str "--number_of_batches 8 --temperature 0.1"
 ```
 
 ### Validation
 ```bash
 # Chai (fast, no MSA)
-uvx modal run modal_chai1.py --fasta-path designs.fasta --output-dir predictions/
+uvx modal run modal_chai1.py --input-faa designs.fasta --out-dir predictions/
 
 # Boltz (open-source)
-uvx modal run modal_boltz.py --fasta-path designs.fasta --output-dir predictions/
+uvx modal run modal_boltz.py --input-faa designs.fasta --out-dir predictions/
 ```
 
 ## GPU selection

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ Options:
 curl -o target.pdb https://files.rcsb.org/download/1ALU.pdb
 ```
 
-### Run BoltzGen (Recommended Pipeline)
+### Run BoltzGen
 ```bash
 uvx modal run modal_boltzgen.py --target target.pdb --num-designs 5
 ```
@@ -98,7 +98,7 @@ Expected output:
 
 ### Design
 ```bash
-# BoltzGen (recommended - all-atom)
+# BoltzGen (all-atom, single-step)
 uvx modal run modal_boltzgen.py --target target.pdb --num-designs 50
 
 # RFdiffusion (backbone generation)
@@ -171,6 +171,6 @@ First run downloads model weights (~5-10 min). Subsequent runs are faster.
 
 ## See also
 
-- [Skills](skills.md) - All 21 skills
+- [Skills](skills.md) - All 22 skills
 - [Standard pipeline](standard-pipeline.md) - Full workflow details
 - [Compute setup](compute-setup.md) - Modal vs local setup

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-All 22 skills available in Protein Design Skills.
+All 24 skills available in Protein Design Skills.
 
 ## Install
 
@@ -13,8 +13,8 @@ Or install specific categories:
 
 | Command | Skills | Description |
 |---------|--------|-------------|
-| `/plugin install adaptyv@protein-design-skills` | 22 | Everything |
-| `/plugin install design-tools@protein-design-skills` | 11 | BoltzGen, BindCraft, RFdiffusion, Mosaic, ProteinMPNN, Chai, etc. |
+| `/plugin install adaptyv@protein-design-skills` | 24 | Everything |
+| `/plugin install design-tools@protein-design-skills` | 13 | BoltzGen, BindCraft, RFdiffusion, Mosaic, Germinal, Protenix, Chai, etc. |
 | `/plugin install evaluation@protein-design-skills` | 2 | protein-qc, ipsae |
 | `/plugin install utilities@protein-design-skills` | 4 | pdb, uniprot, foldseek, setup |
 | `/plugin install experimental@protein-design-skills` | 2 | cell-free-expression, binding-characterization |
@@ -22,7 +22,7 @@ Or install specific categories:
 
 ---
 
-## Design tools (11)
+## Design tools (13)
 
 | Skill | Purpose |
 |-------|---------|
@@ -30,6 +30,8 @@ Or install specific categories:
 | `bindcraft` | End-to-end binder design |
 | `rfdiffusion` | Backbone generation |
 | `mosaic` | Multi-objective gradient design |
+| `germinal` | Antibody / nanobody design |
+| `protenix` | Structure prediction (open AF3) |
 | `proteinmpnn` | Inverse folding |
 | `ligandmpnn` | Ligand-aware sequence design |
 | `solublempnn` | Solubility-optimized design |
@@ -75,7 +77,7 @@ Or install specific categories:
 
 For detailed usage of each skill, see the individual skill documentation:
 
-- **Design tools**: [BoltzGen](../skills/boltzgen/SKILL.md), [BindCraft](../skills/bindcraft/SKILL.md), [RFdiffusion](../skills/rfdiffusion/SKILL.md), [Mosaic](../skills/mosaic/SKILL.md), [ProteinMPNN](../skills/proteinmpnn/SKILL.md), [LigandMPNN](../skills/ligandmpnn/SKILL.md), [SolubleMPNN](../skills/solublempnn/SKILL.md), [Chai](../skills/chai/SKILL.md), [Boltz](../skills/boltz/SKILL.md), [AlphaFold](../skills/alphafold/SKILL.md), [ESM](../skills/esm/SKILL.md)
+- **Design tools**: [BoltzGen](../skills/boltzgen/SKILL.md), [BindCraft](../skills/bindcraft/SKILL.md), [RFdiffusion](../skills/rfdiffusion/SKILL.md), [Mosaic](../skills/mosaic/SKILL.md), [Germinal](../skills/germinal/SKILL.md), [ProteinMPNN](../skills/proteinmpnn/SKILL.md), [LigandMPNN](../skills/ligandmpnn/SKILL.md), [SolubleMPNN](../skills/solublempnn/SKILL.md), [Chai](../skills/chai/SKILL.md), [Boltz](../skills/boltz/SKILL.md), [Protenix](../skills/protenix/SKILL.md), [AlphaFold](../skills/alphafold/SKILL.md), [ESM](../skills/esm/SKILL.md)
 
 - **Evaluation**: [Protein QC](../skills/protein-qc/SKILL.md), [ipSAE](../skills/ipsae/SKILL.md)
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-All 21 skills available in Protein Design Skills.
+All 22 skills available in Protein Design Skills.
 
 ## Install
 
@@ -13,8 +13,8 @@ Or install specific categories:
 
 | Command | Skills | Description |
 |---------|--------|-------------|
-| `/plugin install adaptyv@protein-design-skills` | 21 | Everything |
-| `/plugin install design-tools@protein-design-skills` | 10 | BoltzGen, BindCraft, RFdiffusion, ProteinMPNN, Chai, etc. |
+| `/plugin install adaptyv@protein-design-skills` | 22 | Everything |
+| `/plugin install design-tools@protein-design-skills` | 11 | BoltzGen, BindCraft, RFdiffusion, Mosaic, ProteinMPNN, Chai, etc. |
 | `/plugin install evaluation@protein-design-skills` | 2 | protein-qc, ipsae |
 | `/plugin install utilities@protein-design-skills` | 4 | pdb, uniprot, foldseek, setup |
 | `/plugin install experimental@protein-design-skills` | 2 | cell-free-expression, binding-characterization |
@@ -22,13 +22,14 @@ Or install specific categories:
 
 ---
 
-## Design tools (10)
+## Design tools (11)
 
 | Skill | Purpose |
 |-------|---------|
-| `boltzgen` | All-atom diffusion (recommended) |
+| `boltzgen` | All-atom diffusion design |
 | `bindcraft` | End-to-end binder design |
 | `rfdiffusion` | Backbone generation |
+| `mosaic` | Multi-objective gradient design |
 | `proteinmpnn` | Inverse folding |
 | `ligandmpnn` | Ligand-aware sequence design |
 | `solublempnn` | Solubility-optimized design |
@@ -74,7 +75,7 @@ Or install specific categories:
 
 For detailed usage of each skill, see the individual skill documentation:
 
-- **Design tools**: [BoltzGen](../skills/boltzgen/SKILL.md), [BindCraft](../skills/bindcraft/SKILL.md), [RFdiffusion](../skills/rfdiffusion/SKILL.md), [ProteinMPNN](../skills/proteinmpnn/SKILL.md), [LigandMPNN](../skills/ligandmpnn/SKILL.md), [SolubleMPNN](../skills/solublempnn/SKILL.md), [Chai](../skills/chai/SKILL.md), [Boltz](../skills/boltz/SKILL.md), [AlphaFold](../skills/alphafold/SKILL.md), [ESM](../skills/esm/SKILL.md)
+- **Design tools**: [BoltzGen](../skills/boltzgen/SKILL.md), [BindCraft](../skills/bindcraft/SKILL.md), [RFdiffusion](../skills/rfdiffusion/SKILL.md), [Mosaic](../skills/mosaic/SKILL.md), [ProteinMPNN](../skills/proteinmpnn/SKILL.md), [LigandMPNN](../skills/ligandmpnn/SKILL.md), [SolubleMPNN](../skills/solublempnn/SKILL.md), [Chai](../skills/chai/SKILL.md), [Boltz](../skills/boltz/SKILL.md), [AlphaFold](../skills/alphafold/SKILL.md), [ESM](../skills/esm/SKILL.md)
 
 - **Evaluation**: [Protein QC](../skills/protein-qc/SKILL.md), [ipSAE](../skills/ipsae/SKILL.md)
 

--- a/docs/standard-pipeline.md
+++ b/docs/standard-pipeline.md
@@ -72,11 +72,12 @@ For maximum diversity or backbone-only control:
 
 **Step 1: Backbone Generation** (`rfdiffusion`)
 ```bash
-uvx modal run modal_rfdiffusion.py \
-  --input-pdb target_chainA.pdb \
-  --contigs "A1-150/0 70-90" \
-  --hotspot-res "A42,A58,A62" \
-  --num-designs 100
+# RFdiffusion runs from the official repo, not biomodals
+python run_inference.py \
+  inference.input_pdb=target_chainA.pdb \
+  contigmap.contigs=[A1-150/0 70-90] \
+  ppi.hotspot_res=[A42,A58,A62] \
+  inference.num_designs=100
 ```
 
 **Step 2: Sequence Design** (`ligandmpnn`)
@@ -169,6 +170,6 @@ After filtering:
 
 ## See also
 
-- [Skills](skills.md) - All 22 skills
+- [Skills](skills.md) - All 24 skills
 - [Getting started](getting-started.md) - Setup guide
 - [Compute setup](compute-setup.md) - Modal vs local setup

--- a/docs/standard-pipeline.md
+++ b/docs/standard-pipeline.md
@@ -2,14 +2,19 @@
 
 End-to-end protein binder design workflow.
 
-## Recommended: BoltzGen pipeline
+No single design tool is best for every target. This page walks through a BoltzGen
+pipeline and an RFdiffusion alternative; pick by target type and compute. BindCraft
+and Mosaic are also options (see the `binder-design` skill).
+
+## BoltzGen pipeline
 
 ```
 Target → BoltzGen → Validate → Filter → Experiment
  (pdb)  (all-atom)   (chai)     (qc)    (cfps/spr)
 ```
 
-BoltzGen provides all-atom design with built-in side-chain packing - no separate sequence design step needed.
+BoltzGen provides all-atom design with built-in side-chain packing, so it needs no
+separate sequence design step.
 
 ### Why BoltzGen?
 - **All-atom output**: Backbone + sequence + side chains in one step
@@ -46,7 +51,7 @@ io.save('target_chainA.pdb', ChainSelect())
 - [ ] Residue numbering verified
 - [ ] 3-6 hotspots identified (surface-exposed)
 
-## Phase 2: Design with BoltzGen (recommended)
+## Phase 2: Design with BoltzGen
 
 **Skill**: `boltzgen`
 
@@ -125,7 +130,7 @@ print(f"Passing: {len(passing)}")  # Expect 10-15% pass rate
 
 ## Timeline comparison
 
-### BoltzGen pipeline (recommended)
+### BoltzGen pipeline
 | Phase | Tool | Time | Output |
 |-------|------|------|--------|
 | Target prep | pdb | 10 min | 1 PDB |
@@ -164,6 +169,6 @@ After filtering:
 
 ## See also
 
-- [Skills](skills.md) - All 21 skills
+- [Skills](skills.md) - All 22 skills
 - [Getting started](getting-started.md) - Setup guide
 - [Compute setup](compute-setup.md) - Modal vs local setup

--- a/docs/standard-pipeline.md
+++ b/docs/standard-pipeline.md
@@ -56,9 +56,10 @@ io.save('target_chainA.pdb', ChainSelect())
 **Skill**: `boltzgen`
 
 ```bash
+# BoltzGen takes a YAML design spec (binding site set inside it); see the boltzgen skill
 uvx modal run modal_boltzgen.py \
-  --target target_chainA.pdb \
-  --hotspot-res "A42,A58,A62" \
+  --input-yaml binder.yaml \
+  --protocol protein-anything \
   --num-designs 50
 ```
 
@@ -83,9 +84,8 @@ python run_inference.py \
 **Step 2: Sequence Design** (`ligandmpnn`)
 ```bash
 uvx modal run modal_ligandmpnn.py \
-  --pdb-path output/output_0.pdb \
-  --num-seq-per-target 8 \
-  --sampling-temp 0.1
+  --input-pdb output/output_0.pdb \
+  --params-str "--number_of_batches 8 --temperature 0.1"
 ```
 
 **Expected**: 100 backbones × 8 sequences = 800 sequences
@@ -97,8 +97,8 @@ uvx modal run modal_ligandmpnn.py \
 ```bash
 # Validate with Chai
 uvx modal run modal_chai1.py \
-  --fasta-path all_designs.fasta \
-  --output-dir predictions/
+  --input-faa all_designs.fasta \
+  --out-dir predictions/
 ```
 
 **Expected**: Predictions with pLDDT, pTM, ipTM scores

--- a/docs/tool-selection.md
+++ b/docs/tool-selection.md
@@ -8,9 +8,12 @@ Master decision tree for choosing the right protein design tool.
 What are you designing?
 │
 ├─ Miniprotein binder (60-100 AA)
-│  ├─ Need diversity/exploration → rfdiffusion
-│  ├─ Need high success rate → bindcraft
-│  └─ Need all-atom precision → boltzgen
+│  ├─ Highest hit-rate, willing to tune → mosaic
+│  ├─ Cheap, turnkey, all-atom default → boltzgen
+│  ├─ Diversity/exploration → rfdiffusion
+│  └─ End-to-end with validation → bindcraft
+│
+├─ Antibody / nanobody → germinal
 │
 ├─ Sequence design (have backbone)
 │  ├─ Standard design → proteinmpnn
@@ -18,9 +21,11 @@ What are you designing?
 │  └─ Need solubility → solublempnn
 │
 └─ Structure prediction (validation)
-   ├─ Need open weights → boltz
+   ├─ Need open weights → boltz, chai, or protenix
    └─ Need highest accuracy → alphafold
 ```
+
+Hit-rate is target-dependent; see the `binder-design` skill for head-to-head results.
 
 ## Tool comparison
 
@@ -28,9 +33,11 @@ What are you designing?
 
 | Tool | Method | Strengths | Weaknesses | Best For |
 |------|--------|-----------|------------|----------|
-| rfdiffusion | Diffusion | High diversity, fast | Needs ProteinMPNN | Exploration |
-| bindcraft | End-to-end | High success rate | Less diverse | Production |
-| boltzgen | All-atom diffusion | Side-chain aware | Slower | Precision |
+| mosaic | Gradient, multi-model | Highest competition hit-rate | Needs tuning, local JAX | Hard targets |
+| boltzgen | All-atom diffusion | Cheap, turnkey, side-chain aware | Lower hit-rate on hard targets | Budget default |
+| rfdiffusion | Diffusion | High diversity | Needs ProteinMPNN; not in biomodals | Exploration |
+| bindcraft | End-to-end | Built-in AF2 validation | Less diverse | Production |
+| germinal | Hallucination + AbMPNN | Antibody / nanobody formats | Finicky | scFv / VHH |
 
 ### Sequence tools
 
@@ -45,7 +52,8 @@ What are you designing?
 | Tool | MSA | Speed | Best For |
 |------|-----|-------|----------|
 | chai | No | ~20-40s | Speed + ligands |
-| boltz | No | ~15-30s | Open weights |
+| boltz | No | ~15-30s | Open weights, Boltz-2 affinity |
+| protenix | Optional | ~60s+ | Open AF3 reproduction |
 | alphafold | Yes | ~60s+ | High accuracy |
 
 ## Recommended combinations

--- a/docs/tool-selection.md
+++ b/docs/tool-selection.md
@@ -8,8 +8,8 @@ Master decision tree for choosing the right protein design tool.
 What are you designing?
 │
 ├─ Miniprotein binder (60-100 AA)
-│  ├─ Highest hit-rate, willing to tune → mosaic
-│  ├─ Cheap, turnkey, all-atom default → boltzgen
+│  ├─ Lowest cost/effort default → boltzgen
+│  ├─ Hard/important target, can tune → mosaic
 │  ├─ Diversity/exploration → rfdiffusion
 │  └─ End-to-end with validation → bindcraft
 │
@@ -22,10 +22,12 @@ What are you designing?
 │
 └─ Structure prediction (validation)
    ├─ Need open weights → boltz, chai, or protenix
+   ├─ Antibody-antigen complex → protenix-v2
    └─ Need highest accuracy → alphafold
 ```
 
-Hit-rate is target-dependent; see the `binder-design` skill for head-to-head results.
+Hit-rate is target-dependent for every method and you cannot know a priori which wins;
+pick by cost/effort to a binder. See the `binder-design` skill for head-to-head results.
 
 ## Tool comparison
 
@@ -33,8 +35,8 @@ Hit-rate is target-dependent; see the `binder-design` skill for head-to-head res
 
 | Tool | Method | Strengths | Weaknesses | Best For |
 |------|--------|-----------|------------|----------|
-| mosaic | Gradient, multi-model | Highest competition hit-rate | Needs tuning, local JAX | Hard targets |
-| boltzgen | All-atom diffusion | Cheap, turnkey, side-chain aware | Lower hit-rate on hard targets | Budget default |
+| boltzgen | All-atom diffusion | Cheap, turnkey, side-chain aware | One model in the loop | Lowest cost/effort default |
+| mosaic | Gradient, multi-model | Composable objective, won hard head-to-heads | Needs tuning, local JAX | Hard/important targets |
 | rfdiffusion | Diffusion | High diversity | Needs ProteinMPNN; not in biomodals | Exploration |
 | bindcraft | End-to-end | Built-in AF2 validation | Less diverse | Production |
 | germinal | Hallucination + AbMPNN | Antibody / nanobody formats | Finicky | scFv / VHH |
@@ -53,7 +55,7 @@ Hit-rate is target-dependent; see the `binder-design` skill for head-to-head res
 |------|-----|-------|----------|
 | chai | No | ~20-40s | Speed + ligands |
 | boltz | No | ~15-30s | Open weights, Boltz-2 affinity |
-| protenix | Optional | ~60s+ | Open AF3 reproduction |
+| protenix | Optional | ~60s+ | Open AF3 reproduction; v2 for antibody-antigen |
 | alphafold | Yes | ~60s+ | High accuracy |
 
 ## Recommended combinations

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -20,9 +20,9 @@
     "modal": "optional (recommended for GPU execution)",
     "gpu": "optional (required for local execution)"
   },
-  "skills_count": 22,
+  "skills_count": 24,
   "skill_categories": {
-    "design-tools": 11,
+    "design-tools": 13,
     "evaluation": 2,
     "utilities": 4,
     "experimental": 2,

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Protein Design Skills",
   "description": "Computational protein design tools for Claude Code - backbone generation, sequence design, structure prediction, and experimental validation",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "tudor@adaptyv",
   "repository": "https://github.com/adaptyvbio/protein-design-skills",
   "homepage": "https://www.adaptyvbio.com",
@@ -20,11 +20,11 @@
     "modal": "optional (recommended for GPU execution)",
     "gpu": "optional (required for local execution)"
   },
-  "skills_count": 20,
+  "skills_count": 22,
   "skill_categories": {
-    "design-tools": 10,
+    "design-tools": 11,
     "evaluation": 2,
-    "utilities": 3,
+    "utilities": 4,
     "experimental": 2,
     "orchestration": 3
   },

--- a/skills/alphafold/SKILL.md
+++ b/skills/alphafold/SKILL.md
@@ -32,11 +32,11 @@ biomodals_script: modal_alphafold.py
 
 > **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
-### Option 1: ColabFold (recommended for multimer)
+### Option 1: Modal (AlphaFold-Multimer)
 ```bash
 cd biomodals
 modal run modal_alphafold.py \
-  --input-faa sequences.fasta \
+  --input-fasta sequences.fasta \
   --out-dir output/
 ```
 
@@ -44,7 +44,7 @@ modal run modal_alphafold.py \
 
 ### Option 2: Local installation
 ```bash
-git clone https://github.com/deepmind/alphafold.git
+git clone https://github.com/google-deepmind/alphafold.git
 cd alphafold
 
 python run_alphafold.py \

--- a/skills/alphafold/SKILL.md
+++ b/skills/alphafold/SKILL.md
@@ -35,7 +35,7 @@ biomodals_script: modal_alphafold.py
 ### Option 1: ColabFold (recommended for multimer)
 ```bash
 cd biomodals
-modal run modal_colabfold.py \
+modal run modal_alphafold.py \
   --input-faa sequences.fasta \
   --out-dir output/
 ```
@@ -54,10 +54,10 @@ python run_alphafold.py \
   --max_template_date=2026-01-01
 ```
 
-### Option 3: ESMFold (fast single-chain)
+### Option 3: ESMFold2 (fast single-sequence)
 ```bash
-modal run modal_esmfold.py \
-  --sequence "MKTAYIAKQRQISFVK..."
+printf '>protein|A\nMKTAYIAKQRQISFVK...\n' > seq.faa
+uv run --with modal modal run modal_esmfold2.py --input-faa seq.faa
 ```
 
 ## Key parameters

--- a/skills/alphafold/SKILL.md
+++ b/skills/alphafold/SKILL.md
@@ -30,7 +30,7 @@ biomodals_script: modal_alphafold.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: ColabFold (recommended for multimer)
 ```bash

--- a/skills/bindcraft/SKILL.md
+++ b/skills/bindcraft/SKILL.md
@@ -38,47 +38,40 @@ biomodals_script: modal_bindcraft.py
 ```bash
 cd biomodals
 modal run modal_bindcraft.py \
-  --target-pdb target.pdb \
-  --target-chain A \
-  --binder-lengths 70-100 \
-  --hotspots "A45,A67,A89" \
-  --num-designs 50
+  --input-pdb target.pdb \
+  --target-chains A \
+  --target-hotspot-residues "45,67,89" \
+  --lengths "70,100" \
+  --number-of-final-designs 50
 ```
 
-**GPU**: L40S (48GB) | **Timeout**: 3600s default
+**GPU**: L40S (48GB) | **Timeout**: 300 min default
 
 ### Option 2: Local installation
 ```bash
 git clone https://github.com/martinpacesa/BindCraft.git
 cd BindCraft
-pip install -r requirements.txt
 
-python bindcraft.py \
-  --target target.pdb \
-  --target_chains A \
-  --binder_lengths 70-100 \
-  --hotspots A45,A67,A89 \
-  --num_designs 50
+# BindCraft is configured with JSON files, not flags
+python -u ./bindcraft.py \
+  --settings ./settings_target/mytarget.json \
+  --filters ./settings_filters/default_filters.json \
+  --advanced ./settings_advanced/default_4stage_multimer.json
 ```
 
-## Key parameters
+The target PDB, chains, hotspots, and binder length range are set inside the
+`--settings` JSON. See the BindCraft repo for the settings schema.
 
-| Parameter | Default | Range | Description |
-|-----------|---------|-------|-------------|
-| `--target-pdb` | required | path | Target structure |
-| `--target-chain` | required | A-Z | Target chain(s) |
-| `--binder-lengths` | 70-100 | 40-150 | Length range |
-| `--hotspots` | None | residues | Target hotspots |
-| `--num-designs` | 50 | 1-500 | Number of designs |
-| `--protocol` | default | fast/default/slow | Quality vs speed |
+## Key parameters (Modal wrapper)
 
-## Protocols
-
-| Protocol | Speed | Quality | Use Case |
-|----------|-------|---------|----------|
-| fast | Fast | Lower | Initial screening |
-| default | Medium | Good | Standard campaigns |
-| slow | Slow | High | Final production |
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--input-pdb` | required | Target structure |
+| `--target-chains` | `A` | Target chain(s) |
+| `--target-hotspot-residues` | "" | Target hotspots (e.g. "45,67,89") |
+| `--lengths` | `50,130` | Binder length range |
+| `--number-of-final-designs` | 1 | Passing designs to return |
+| `--max-trajectories` | none | Cap on trajectories |
 
 ## Output format
 
@@ -110,12 +103,11 @@ output/
 
 ### Successful run
 ```
-$ modal run modal_bindcraft.py --target-pdb target.pdb --num-designs 50
+$ modal run modal_bindcraft.py --input-pdb target.pdb --target-chains A --target-hotspot-residues "45,67,89" --number-of-final-designs 50
 [INFO] Loading BindCraft model...
 [INFO] Target: target.pdb (chain A)
-[INFO] Hotspots: A45, A67, A89
-[INFO] Protocol: default
-[INFO] Generating 50 designs...
+[INFO] Hotspots: 45, 67, 89
+[INFO] Generating designs...
 
 Design 1/50:
   Length: 78 AA

--- a/skills/bindcraft/SKILL.md
+++ b/skills/bindcraft/SKILL.md
@@ -158,7 +158,11 @@ Should I use BindCraft?
 | 100 designs | 4-8h | ~$30 | Standard |
 | 200 designs | 8-16h | ~$60 | Large campaign |
 
-**Expected pass rate**: 30-70% with ipTM > 0.5 (target-dependent).
+Adaptyv's own tests of these models showed BindCraft costing about $2.90 per accepted
+design, averaged across 7 targets.
+
+**Experimental success rate** (BindCraft paper): 10 to 100%, averaging 46.3% across 12
+targets; strongly target-dependent.
 
 ---
 

--- a/skills/bindcraft/SKILL.md
+++ b/skills/bindcraft/SKILL.md
@@ -32,7 +32,7 @@ biomodals_script: modal_bindcraft.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal (recommended)
 ```bash

--- a/skills/binder-design/SKILL.md
+++ b/skills/binder-design/SKILL.md
@@ -38,8 +38,8 @@ Boltz, BindCraft, Mosaic). You cannot know a priori which will win on a new targ
 this is not a fixed leaderboard.
 
 Because of that, choose a starting point by **cost and effort to a binder**, not by
-assuming a method has the best hit-rate. BoltzGen is the suggested default purely
-because it is cheap, turnkey, and all-atom, so it gets you testable designs fastest.
+assuming a method has the best hit-rate. BoltzGen is the suggested default because it is
+turnkey and all-atom, so it gets you testable designs fastest with the least setup.
 Mosaic is the high-ceiling option when you can invest time tuning the objective. On a
 hard or important target, running more than one method in parallel is reasonable.
 
@@ -58,18 +58,40 @@ De novo binder design?
 
 | Tool | Strengths | Weaknesses | Best for |
 |------|-----------|------------|----------|
-| BoltzGen | All-atom, single-step, cheap, turnkey | One model in the loop | Lowest cost/effort default, ligand binding |
+| BoltzGen | All-atom, single-step, turnkey | One model in the loop; mid-range cost per design | Lowest-effort default, ligand binding |
 | Mosaic | Composable multi-model objective, won hard head-to-heads | Needs tuning, local JAX only | Hard or important targets, expert use |
 | BindCraft | End-to-end, built-in AF2 validation | Less diverse | Production campaigns |
 | RFdiffusion | High diversity | Requires ProteinMPNN; not in biomodals | Exploration, diversity |
 | Germinal | Antibody and nanobody formats | Finicky | scFv / VHH design |
 
-## Compute vs hit-rate tradeoff
+## Compute cost per design
 
-- **Budget / quick exploration**: BoltzGen is cheap (about $8 for 50 designs) and needs
-  no tuning. Good first pass and good for ligand binding.
+Adaptyv's own tests of these models showed the following compute cost per accepted
+design, averaged across 7 targets (it varies several-fold by target):
+
+| Method | Cost per design |
+|--------|-----------------|
+| RSO | ~$0.15 |
+| RFdiffusion | ~$0.25 |
+| Mosaic | ~$0.55 |
+| ESMFold2 inversion | ~$0.85 |
+| mBER | ~$1.40 |
+| Germinal | ~$1.60 |
+| BoltzGen | ~$1.80 |
+| BindCraft | ~$2.90 |
+
+Per-design compute cost is not the same as cost to a binder, which also depends on the
+hit-rate on your target. The gradient methods (RSO, Mosaic) are cheap per design but
+need setup and tuning; BoltzGen and BindCraft cost more per design but are turnkey, so
+their advantage is low human effort rather than lowest compute cost.
+
+## Compute vs effort tradeoff
+
+- **Lowest human effort**: BoltzGen needs no tuning and runs through biomodals. Good
+  first pass and good for ligand binding.
 - **Highest ceiling on a hard target**: Mosaic, given time to design and tune the
-  objective. It runs locally on a JAX GPU rather than through biomodals.
+  objective. It runs locally on a JAX GPU rather than through biomodals, and is cheap
+  per design.
 - Whatever the generator, validate with `boltz` or `chai` and rank with `ipsae`.
 
 Other biomodals-backed options: `modal_rso.py` (Rejection Sampling Optimization, an
@@ -78,7 +100,7 @@ nanobodies.
 
 ## Example pipeline: BoltzGen → Chai → QC
 
-BoltzGen provides all-atom design with built-in side-chain packing. This is one cheap,
+BoltzGen provides all-atom design with built-in side-chain packing. This is one
 turnkey path; swap in Mosaic, RFdiffusion, or BindCraft depending on the target.
 
 ```

--- a/skills/binder-design/SKILL.md
+++ b/skills/binder-design/SKILL.md
@@ -18,45 +18,44 @@ tags: [guidance, tool-selection, workflow]
 
 ## Decision tree
 
+No single tool is best for every target. Pick by target type, what you want to
+control, and available compute.
+
 ```
 De novo binder design?
 │
-├─ Standard target → BoltzGen (recommended)
-│   All-atom output (no separate ProteinMPNN step needed)
-│   Better for ligand/small molecule binding
+├─ All-atom design or ligand/small-molecule binding → BoltzGen
+│   All-atom output (no separate ProteinMPNN step)
 │   Single-step design (backbone + sequence + side chains)
+│   Higher GPU requirement
 │
-├─ Need diversity/exploration → RFdiffusion + ProteinMPNN
-│   Maximum backbone diversity
-│   Two-step: backbone then sequence
+├─ Diversity / exploration → RFdiffusion + ProteinMPNN
+│   Maximum backbone diversity, two-step
 │
-├─ Integrated validation → BindCraft
-│   Built-in AF2 validation
-│   End-to-end pipeline
+├─ End-to-end with built-in validation → BindCraft
+│   AF2 validation in the loop
 │
-├─ Ligand binding → BoltzGen ✓
-│   All-atom diffusion handles ligand context
+├─ Custom multi-model objective → Mosaic
+│   Gradient optimization, compose several predictors
 │
-├─ Peptide/nanobody → Germinal
-│   VHH/nanobody design
-│   Germline-aware optimization
-│
-└─ Antibody/Nanobody
-    +-- VHH design --> germinal skill
+└─ Antibody / nanobody (VHH)
+    External tools, not yet packaged as skills:
+    Germinal and RFantibody
 ```
 
 ## Tool comparison
 
 | Tool | Strengths | Weaknesses | Best For |
 |------|-----------|------------|----------|
-| BoltzGen | All-atom, single-step, ligand-aware | Higher GPU requirement | Standard (recommended) |
+| BoltzGen | All-atom, single-step, ligand-aware | Higher GPU requirement | All-atom and ligand binding |
 | BindCraft | End-to-end, built-in AF2 validation | Less diverse | Production campaigns |
 | RFdiffusion | High diversity, fast | Requires ProteinMPNN | Exploration, diversity |
-| Germinal | Nanobody/VHH design | Specialized | Antibody optimization |
+| Mosaic | Compose any predictors, custom loss | Needs tuning, no default filters | Custom objectives |
 
-## Recommended Pipeline: BoltzGen → Chai → QC
+## Example pipeline: BoltzGen → Chai → QC
 
-BoltzGen provides all-atom design with built-in side-chain packing:
+BoltzGen provides all-atom design with built-in side-chain packing. This is one
+solid path; swap in RFdiffusion, BindCraft, or Mosaic depending on the target.
 
 ```
 Target → BoltzGen → Validate → Filter
@@ -77,7 +76,7 @@ Target → BoltzGen → Validate → Filter
 - Prefer charged/aromatic residues
 - Cluster spatially (within 10-15A)
 
-### 3. Design with BoltzGen (Recommended)
+### 3. Design with BoltzGen
 
 First, create a YAML config file (e.g., `binder.yaml`):
 ```yaml

--- a/skills/binder-design/SKILL.md
+++ b/skills/binder-design/SKILL.md
@@ -32,16 +32,22 @@ against the same target. On the Adaptyv Nipah de novo target, the public results
 | BindCraft | 98 | 7 | 7% |
 | BoltzGen | 182 | 6 | 3% |
 
-Mosaic had the highest hit-rate, but on a small, expert-tuned sample, and the ranking
-shifts on other targets. Treat this as evidence that a well-designed gradient objective
-can win on hard targets, not as a fixed leaderboard. BoltzGen remains a strong, cheap,
-turnkey default; Mosaic is the high-ceiling option when you can invest tuning time.
+Mosaic had the highest hit-rate here, but on a small, expert-tuned sample. The ranking
+shifts on other targets, and that target-dependence is true of every method (BoltzGen,
+Boltz, BindCraft, Mosaic). You cannot know a priori which will win on a new target, so
+this is not a fixed leaderboard.
+
+Because of that, choose a starting point by **cost and effort to a binder**, not by
+assuming a method has the best hit-rate. BoltzGen is the suggested default purely
+because it is cheap, turnkey, and all-atom, so it gets you testable designs fastest.
+Mosaic is the high-ceiling option when you can invest time tuning the objective. On a
+hard or important target, running more than one method in parallel is reasonable.
 
 ```
 De novo binder design?
 │
-├─ Highest hit-rate, willing to tune → Mosaic (gradient, multi-model objective)
-├─ Cheap, turnkey, all-atom default → BoltzGen
+├─ Lowest cost/effort to testable designs → BoltzGen (default)
+├─ Hard/important target, can invest tuning → Mosaic (gradient, multi-model)
 ├─ Ligand / small-molecule binding → BoltzGen (all-atom)
 ├─ Diversity / exploration → RFdiffusion + ProteinMPNN
 ├─ End-to-end with built-in validation → BindCraft
@@ -52,8 +58,8 @@ De novo binder design?
 
 | Tool | Strengths | Weaknesses | Best for |
 |------|-----------|------------|----------|
-| Mosaic | Highest competition hit-rate, composable objective | Needs tuning, local JAX only | Hard targets, expert use |
-| BoltzGen | All-atom, single-step, cheap, turnkey | Lower hit-rate on hard targets | Budget default, ligand binding |
+| BoltzGen | All-atom, single-step, cheap, turnkey | One model in the loop | Lowest cost/effort default, ligand binding |
+| Mosaic | Composable multi-model objective, won hard head-to-heads | Needs tuning, local JAX only | Hard or important targets, expert use |
 | BindCraft | End-to-end, built-in AF2 validation | Less diverse | Production campaigns |
 | RFdiffusion | High diversity | Requires ProteinMPNN; not in biomodals | Exploration, diversity |
 | Germinal | Antibody and nanobody formats | Finicky | scFv / VHH design |
@@ -62,7 +68,7 @@ De novo binder design?
 
 - **Budget / quick exploration**: BoltzGen is cheap (about $8 for 50 designs) and needs
   no tuning. Good first pass and good for ligand binding.
-- **Best hit-rate on a hard target**: Mosaic, given time to design and tune the
+- **Highest ceiling on a hard target**: Mosaic, given time to design and tune the
   objective. It runs locally on a JAX GPU rather than through biomodals.
 - Whatever the generator, validate with `boltz` or `chai` and rank with `ipsae`.
 
@@ -139,9 +145,8 @@ python run_inference.py \
 
 # Step 2: Sequence design
 modal run modal_ligandmpnn.py \
-  --pdb-path backbone.pdb \
-  --num-seq-per-target 16 \
-  --sampling-temp 0.1
+  --input-pdb backbone.pdb \
+  --params-str "--number_of_batches 16 --temperature 0.1"
 ```
 
 ### 5. Validation

--- a/skills/binder-design/SKILL.md
+++ b/skills/binder-design/SKILL.md
@@ -16,46 +16,64 @@ tags: [guidance, tool-selection, workflow]
 
 # Binder Design Tool Selection
 
-## Decision tree
+## Which tool wins
 
-No single tool is best for every target. Pick by target type, what you want to
-control, and available compute.
+No single tool is best for every target. Hit-rate is strongly target-dependent, so
+choose by target type, what you want to control, and available compute.
+
+The clearest signal comes from head-to-head competitions where many methods design
+against the same target. On the Adaptyv Nipah de novo target, the public results show:
+
+| Method | Tested | Binders | Hit-rate |
+|--------|--------|---------|----------|
+| Mosaic (gradient, multi-model) | 9 | 8 | 89% |
+| ProteinMPNN hybrid | 28 | 7 | 25% |
+| RFdiffusion | 60 | 13 | 22% |
+| BindCraft | 98 | 7 | 7% |
+| BoltzGen | 182 | 6 | 3% |
+
+Mosaic had the highest hit-rate, but on a small, expert-tuned sample, and the ranking
+shifts on other targets. Treat this as evidence that a well-designed gradient objective
+can win on hard targets, not as a fixed leaderboard. BoltzGen remains a strong, cheap,
+turnkey default; Mosaic is the high-ceiling option when you can invest tuning time.
 
 ```
 De novo binder design?
 │
-├─ All-atom design or ligand/small-molecule binding → BoltzGen
-│   All-atom output (no separate ProteinMPNN step)
-│   Single-step design (backbone + sequence + side chains)
-│   Higher GPU requirement
-│
+├─ Highest hit-rate, willing to tune → Mosaic (gradient, multi-model objective)
+├─ Cheap, turnkey, all-atom default → BoltzGen
+├─ Ligand / small-molecule binding → BoltzGen (all-atom)
 ├─ Diversity / exploration → RFdiffusion + ProteinMPNN
-│   Maximum backbone diversity, two-step
-│
 ├─ End-to-end with built-in validation → BindCraft
-│   AF2 validation in the loop
-│
-├─ Custom multi-model objective → Mosaic
-│   Gradient optimization, compose several predictors
-│
-└─ Antibody / nanobody (VHH)
-    External tools, not yet packaged as skills:
-    Germinal and RFantibody
+└─ Antibody / nanobody (VHH) → germinal skill (also mber, iggm in biomodals)
 ```
 
 ## Tool comparison
 
-| Tool | Strengths | Weaknesses | Best For |
+| Tool | Strengths | Weaknesses | Best for |
 |------|-----------|------------|----------|
-| BoltzGen | All-atom, single-step, ligand-aware | Higher GPU requirement | All-atom and ligand binding |
+| Mosaic | Highest competition hit-rate, composable objective | Needs tuning, local JAX only | Hard targets, expert use |
+| BoltzGen | All-atom, single-step, cheap, turnkey | Lower hit-rate on hard targets | Budget default, ligand binding |
 | BindCraft | End-to-end, built-in AF2 validation | Less diverse | Production campaigns |
-| RFdiffusion | High diversity, fast | Requires ProteinMPNN | Exploration, diversity |
-| Mosaic | Compose any predictors, custom loss | Needs tuning, no default filters | Custom objectives |
+| RFdiffusion | High diversity | Requires ProteinMPNN; not in biomodals | Exploration, diversity |
+| Germinal | Antibody and nanobody formats | Finicky | scFv / VHH design |
+
+## Compute vs hit-rate tradeoff
+
+- **Budget / quick exploration**: BoltzGen is cheap (about $8 for 50 designs) and needs
+  no tuning. Good first pass and good for ligand binding.
+- **Best hit-rate on a hard target**: Mosaic, given time to design and tune the
+  objective. It runs locally on a JAX GPU rather than through biomodals.
+- Whatever the generator, validate with `boltz` or `chai` and rank with `ipsae`.
+
+Other biomodals-backed options: `modal_rso.py` (Rejection Sampling Optimization, an
+AlphaFold-based gradient method) for minibinders, and `modal_mber.py` for VHH
+nanobodies.
 
 ## Example pipeline: BoltzGen → Chai → QC
 
-BoltzGen provides all-atom design with built-in side-chain packing. This is one
-solid path; swap in RFdiffusion, BindCraft, or Mosaic depending on the target.
+BoltzGen provides all-atom design with built-in side-chain packing. This is one cheap,
+turnkey path; swap in Mosaic, RFdiffusion, or BindCraft depending on the target.
 
 ```
 Target → BoltzGen → Validate → Filter
@@ -112,12 +130,12 @@ modal run modal_boltzgen.py \
 ### 4. Alternative: RFdiffusion Pipeline
 For maximum diversity or when backbone-only is preferred:
 ```bash
-# Step 1: Backbone generation
-modal run modal_rfdiffusion.py \
-  --pdb target.pdb \
-  --contigs "A1-150/0 70-100" \
-  --hotspot "A45,A67,A89" \
-  --num-designs 500
+# Step 1: Backbone generation (RFdiffusion, run from the official repo)
+python run_inference.py \
+  inference.input_pdb=target.pdb \
+  contigmap.contigs=[A1-150/0 70-100] \
+  ppi.hotspot_res=[A45,A67,A89] \
+  inference.num_designs=500
 
 # Step 2: Sequence design
 modal run modal_ligandmpnn.py \

--- a/skills/binding-characterization/SKILL.md
+++ b/skills/binding-characterization/SKILL.md
@@ -203,8 +203,8 @@ Mass transport limitation occurs when analyte cannot diffuse to the surface fast
 - [ ] Fitted Rmax reasonable (close to theoretical)
 
 ### Red flags
-- kon approaching mass transport limit (>10^7 M^-1s^-1)
-- koff faster than data acquisition (< 0.01 s^-1 requires faster sampling)
+- kon approaching the mass transport limit (>10^7 M^-1s^-1), where rates are unreliable
+- koff too fast to sample (> 0.1 s^-1) or too slow to measure in the dissociation window (< 10^-5 s^-1)
 - Rmax >> theoretical maximum (aggregation or avidity)
 - Large difference between kinetic and equilibrium KD
 

--- a/skills/boltz/SKILL.md
+++ b/skills/boltz/SKILL.md
@@ -30,7 +30,7 @@ biomodals_script: modal_boltz.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal
 ```bash
@@ -178,10 +178,22 @@ find predictions -name "*.cif" | wc -l  # Should match input count
 
 | Aspect | Boltz-1 | Boltz-2 |
 |--------|---------|---------|
-| Speed | Fast | ~2x faster |
-| Accuracy | Good | Improved |
+| Speed | Fast | Faster |
+| Accuracy | Good | Improved, notably antibody-antigen |
 | Ligands | Basic | Better support |
-| Release | 2024 | Late 2024 |
+| Affinity prediction | No | Yes (small-molecule binding) |
+| Release | 2024 | 2025 |
+
+Boltz-2 is the current default. Boltz-1 is still used where a design pipeline
+inverts the v1 model.
+
+### Affinity prediction (Boltz-2)
+
+Boltz-2 adds an affinity-prediction module that approaches free-energy-perturbation
+accuracy at a fraction of the cost. It is trained on small-molecule binding data, so
+use it for protein-ligand and small-molecule work. It does not predict
+protein-protein binding affinity; for protein binders, rely on interface confidence
+(ipTM, ipSAE) instead.
 
 ---
 

--- a/skills/boltzgen/SKILL.md
+++ b/skills/boltzgen/SKILL.md
@@ -32,7 +32,7 @@ biomodals_script: modal_boltzgen.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal (recommended)
 ```bash

--- a/skills/boltzgen/SKILL.md
+++ b/skills/boltzgen/SKILL.md
@@ -251,6 +251,10 @@ Should I use BoltzGen?
 
 **Per-design**: ~30-60s for typical binder.
 
+Adaptyv's own tests of these models showed BoltzGen costing about $1.80 per accepted
+design, averaged across 7 targets (the generation estimates above do not include the
+extra sampling and refolding needed to reach an accepted design).
+
 ---
 
 ## Verify

--- a/skills/boltzgen/SKILL.md
+++ b/skills/boltzgen/SKILL.md
@@ -25,7 +25,7 @@ biomodals_script: modal_boltzgen.py
 
 | Requirement | Minimum | Recommended |
 |-------------|---------|-------------|
-| Python | 3.10+ | 3.11 |
+| Python | 3.11+ | 3.12 |
 | CUDA | 12.0+ | 12.1+ |
 | GPU VRAM | 24GB | 48GB (L40S) |
 | RAM | 32GB | 64GB |
@@ -60,22 +60,17 @@ GPU=L40S modal run modal_boltzgen.py \
 ```bash
 git clone https://github.com/HannesStark/boltzgen.git
 cd boltzgen
-pip install -e .
+pip install boltzgen   # or: pip install -e .
 
-python sample.py config=config.yaml
+# Driven by the boltzgen CLI with a YAML design spec
+boltzgen run binder_config.yaml \
+  --output out/ \
+  --protocol protein-anything \
+  --num_designs 50
 ```
 
-### Option 3: Python API
-```python
-from boltzgen import BoltzGen
-
-model = BoltzGen.load_pretrained()
-designs = model.sample(
-    target_pdb="target.pdb",
-    num_samples=50,
-    binder_length=80
-)
-```
+The first run downloads model weights (~6GB) to `~/.cache`. Verify a spec with
+`boltzgen check binder_config.yaml` before a full run.
 
 **GPU**: L40S (48GB) | **Time**: ~30-60s per design
 

--- a/skills/campaign-manager/SKILL.md
+++ b/skills/campaign-manager/SKILL.md
@@ -28,7 +28,7 @@ When user says: "I need 10 good binders for EGFR"
 ```
 Goal: 10 high-quality binders for EGFR
 ├── Achievable: Yes (standard target)
-├── Recommended pipeline: rfdiffusion → proteinmpnn → colabfold → protein-qc
+├── Recommended pipeline: rfdiffusion → proteinmpnn → chai → protein-qc
 ├── Estimated designs needed: 500 backbones (to get ~50 passing QC)
 ├── Estimated time: 8-12 hours total
 ├── Estimated cost: ~$60 (Modal GPU compute)
@@ -64,9 +64,8 @@ python run_inference.py \
 # Step 3: Design sequences (1-2h, ~$10)
 for f in output/*.pdb; do
   modal run modal_ligandmpnn.py \
-    --pdb-path "$f" \
-    --num-seq-per-target 8 \
-    --sampling-temp 0.1
+    --input-pdb "$f" \
+    --params-str "--number_of_batches 8 --temperature 0.1"
 done
 
 # Checkpoint: grep -c "^>" output/seqs/*.fa  # Should be ~4000
@@ -115,8 +114,8 @@ modal run modal_alphafold.py \
 | Standard miniprotein | RFdiffusion + ProteinMPNN | High diversity, proven |
 | Need higher success rate | BindCraft | Integrated design loop |
 | All-atom precision needed | BoltzGen | Side-chain aware |
-| Difficult target | ColabDesign | AF2 gradient optimization |
-| Need fast iteration | ESMFold + ESM2 | Quick screening |
+| Difficult target | Mosaic | Gradient, multi-model objective |
+| Need fast iteration | ESMFold2 + ESM2 | Quick screening |
 
 ### Target difficulty assessment
 
@@ -195,7 +194,7 @@ def assess_campaign(csv_path):
 | RFdiffusion | A10G | ~$1.20 | 500 designs/2h | ~$2.50 |
 | ProteinMPNN | T4 | ~$0.60 | 4000 seq/1.5h | ~$1.00 |
 | ESM2 (PLL) | A10G | ~$1.20 | 4000 seq/30min | ~$0.60 |
-| ColabFold | A100 | ~$4.50 | 4000 preds/4h | ~$18.00 |
+| AlphaFold | A100 | ~$4.50 | 4000 preds/4h | ~$18.00 |
 | Chai | A100 | ~$4.50 | 500 preds/1h | ~$4.50 |
 
 ### Campaign cost estimates
@@ -216,7 +215,7 @@ def assess_campaign(csv_path):
 ```bash
 # More backbones, fewer sequences each (RFdiffusion from the official repo)
 python run_inference.py inference.num_designs=2000
-modal run modal_ligandmpnn.py --num-seq-per-target 4 --sampling-temp 0.2
+modal run modal_ligandmpnn.py --input-pdb bb.pdb --params-str "--number_of_batches 4 --temperature 0.2"
 ```
 
 ### High-quality (maximize per-design quality)
@@ -224,7 +223,7 @@ modal run modal_ligandmpnn.py --num-seq-per-target 4 --sampling-temp 0.2
 ```bash
 # Fewer backbones, more sequences each, lower temperature
 python run_inference.py inference.num_designs=200
-modal run modal_ligandmpnn.py --num-seq-per-target 32 --sampling-temp 0.1
+modal run modal_ligandmpnn.py --input-pdb bb.pdb --params-str "--number_of_batches 32 --temperature 0.1"
 ```
 
 ### Quick exploration (fast iteration)
@@ -232,7 +231,7 @@ modal run modal_ligandmpnn.py --num-seq-per-target 32 --sampling-temp 0.1
 ```bash
 # Small batch, ESMFold2 for fast single-sequence folding
 # RFdiffusion runs from the official repo (not biomodals); see the rfdiffusion skill
-modal run modal_ligandmpnn.py --num-seq-per-target 8
+modal run modal_ligandmpnn.py --input-pdb bb.pdb --params-str "--number_of_batches 8"
 modal run modal_esmfold2.py --input-faa all_seqs.fa
 ```
 
@@ -240,6 +239,6 @@ modal run modal_esmfold2.py --input-faa all_seqs.fa
 
 ## See also
 
-- Tool-specific parameters: `rfdiffusion`, `proteinmpnn`, `colabfold`, `chai`, `boltz`
+- Tool-specific parameters: `rfdiffusion`, `proteinmpnn`, `mosaic`, `chai`, `boltz`, `alphafold`
 - QC thresholds and filtering: `protein-qc`
 - Tool selection guidance: `binder-design`

--- a/skills/campaign-manager/SKILL.md
+++ b/skills/campaign-manager/SKILL.md
@@ -52,17 +52,18 @@ curl -o target.pdb "https://files.rcsb.org/download/{PDB_ID}.pdb"
 # Trim to binding region if needed
 
 # Step 2: Generate backbones (2-3h, ~$15)
-modal run modal_rfdiffusion.py \
-  --pdb target.pdb \
-  --contigs "A1-150/0 70-100" \
-  --hotspot "A45,A67,A89" \
-  --num-designs 500
+# RFdiffusion runs from the official repo, not biomodals
+python run_inference.py \
+  inference.input_pdb=target.pdb \
+  contigmap.contigs=[A1-150/0 70-100] \
+  ppi.hotspot_res=[A45,A67,A89] \
+  inference.num_designs=500
 
 # Checkpoint: ls output/*.pdb | wc -l  # Should be 500
 
 # Step 3: Design sequences (1-2h, ~$10)
 for f in output/*.pdb; do
-  modal run modal_proteinmpnn.py \
+  modal run modal_ligandmpnn.py \
     --pdb-path "$f" \
     --num-seq-per-target 8 \
     --sampling-temp 0.1
@@ -71,11 +72,11 @@ done
 # Checkpoint: grep -c "^>" output/seqs/*.fa  # Should be ~4000
 
 # Step 4: Quick ESM2 filter (30 min, ~$5, optional)
-modal run modal_esm.py --fasta output/all_seqs.fa --mode pll
+modal run modal_esm2_predict_masked.py --input-faa output/all_seqs.fa
 # Filter sequences with PLL < 0.0
 
 # Step 5: Structure validation (3-4h, ~$35)
-modal run modal_colabfold.py \
+modal run modal_alphafold.py \
   --input-faa output/filtered_seqs.fa \
   --out-dir predictions/
 
@@ -213,26 +214,26 @@ def assess_campaign(csv_path):
 ### High-throughput (maximize diversity)
 
 ```bash
-# More backbones, fewer sequences each
-modal run modal_rfdiffusion.py --num-designs 2000
-modal run modal_proteinmpnn.py --num-seq-per-target 4 --sampling-temp 0.2
+# More backbones, fewer sequences each (RFdiffusion from the official repo)
+python run_inference.py inference.num_designs=2000
+modal run modal_ligandmpnn.py --num-seq-per-target 4 --sampling-temp 0.2
 ```
 
 ### High-quality (maximize per-design quality)
 
 ```bash
 # Fewer backbones, more sequences each, lower temperature
-modal run modal_rfdiffusion.py --num-designs 200
-modal run modal_proteinmpnn.py --num-seq-per-target 32 --sampling-temp 0.1
+python run_inference.py inference.num_designs=200
+modal run modal_ligandmpnn.py --num-seq-per-target 32 --sampling-temp 0.1
 ```
 
 ### Quick exploration (fast iteration)
 
 ```bash
-# Small batch, ESMFold instead of ColabFold
-modal run modal_rfdiffusion.py --num-designs 50
-modal run modal_proteinmpnn.py --num-seq-per-target 8
-modal run modal_esmfold.py --fasta all_seqs.fa  # Faster than ColabFold
+# Small batch, ESMFold2 for fast single-sequence folding
+# RFdiffusion runs from the official repo (not biomodals); see the rfdiffusion skill
+modal run modal_ligandmpnn.py --num-seq-per-target 8
+modal run modal_esmfold2.py --input-faa all_seqs.fa
 ```
 
 ---

--- a/skills/chai/SKILL.md
+++ b/skills/chai/SKILL.md
@@ -30,7 +30,7 @@ biomodals_script: modal_chai1.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal
 ```bash

--- a/skills/esm/SKILL.md
+++ b/skills/esm/SKILL.md
@@ -146,6 +146,9 @@ uv run --with modal modal run modal_esmfold2_binder_design.py \
 - Rank candidates by ipTM, filter minibinders to pI below 6, then validate the top
   shortlist with `boltz` or `chai` and rank with `ipsae`.
 
+Adaptyv's own tests of these models showed ESMFold2-inversion binder design costing
+about $0.85 per accepted design, averaged across 7 targets.
+
 For a framework that composes ESMFold2 with other predictors in one objective, use the
 `mosaic` skill.
 

--- a/skills/esm/SKILL.md
+++ b/skills/esm/SKILL.md
@@ -1,181 +1,178 @@
 ---
 name: esm
 description: >
-  ESM2 protein language model for embeddings and sequence scoring.
-  Use this skill when: (1) Computing pseudo-log-likelihood (PLL) scores,
-  (2) Getting protein embeddings for clustering,
-  (3) Filtering designs by sequence plausibility,
-  (4) Zero-shot variant effect prediction,
-  (5) Analyzing sequence-function relationships.
+  ESM protein language models for embeddings, sequence scoring, structure
+  prediction, and binder design. Use this skill when: (1) Computing
+  pseudo-log-likelihood (PLL) or mutation-effect scores, (2) Getting protein
+  embeddings for clustering or filtering, (3) Predicting complex structures with
+  ESMFold2, (4) Designing binders by inverting ESMFold2, (5) Filtering designs by
+  sequence plausibility.
 
-  For structure prediction, use chai or boltz.
+  For diffusion-based structure prediction, use boltz or chai.
   For QC thresholds, use protein-qc.
+  For gradient-based multi-objective design, use mosaic.
 license: MIT
 category: design-tools
-tags: [sequence-design, embeddings, scoring]
+tags: [sequence-design, embeddings, scoring, structure-prediction, binder]
 proteinbase_slug: esm2-optimization
 proteinbase_url: https://proteinbase.com/design-methods/esm2-optimization
 biomodals_script: modal_esm2_predict_masked.py
 ---
 
-# ESM2 Protein Language Model
+# ESM Protein Language Models
+
+The ESM line is maintained at [github.com/Biohub/esm](https://github.com/Biohub/esm)
+(Chan Zuckerberg Biohub, MIT license; the older `evolutionaryscale/esm` URL
+redirects here). The current generation ships three artifacts: **ESM C** (language
+model), **ESMFold2** (structure prediction), and **ESM Atlas** (a map of predicted
+structures). Weights are on [huggingface.co/biohub](https://huggingface.co/biohub);
+the hosted API is at `biohub.ai`.
+
+This skill covers ESM C, ESMFold2, and legacy ESM2. ESM3 is not covered because its
+open weights are non-commercial.
+
+## Which model to use
+
+| Task | Model |
+|------|-------|
+| Embeddings, PLL, mutation scoring | ESM C (ESMC-6B), or ESM2 for a lighter run |
+| Complex structure prediction | ESMFold2 |
+| High-throughput single-sequence folding | ESMFold2 fast mode |
+| Binder design | ESMFold2 inversion (see below), or the `mosaic` / `bindcraft` skills |
+| Variant effect / zero-shot scoring | ESM C or ESM2 |
 
 ## Prerequisites
 
 | Requirement | Minimum | Recommended |
 |-------------|---------|-------------|
-| Python | 3.8+ | 3.10 |
-| PyTorch | 1.10+ | 2.0+ |
-| CUDA | 11.0+ | 11.7+ |
-| GPU VRAM | 8GB | 24GB (A10G) |
-| RAM | 16GB | 32GB |
+| Python | 3.10+ | 3.11 |
+| PyTorch | 2.0+ | Latest |
+| CUDA | 12.0+ | 12.1+ |
+| GPU VRAM | 24GB (ESM2 / small ESMC) | 80GB (ESMC-6B, ESMFold2) |
 
-## How to run
+## ESM C: embeddings and scoring
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+ESM C is the successor to ESM2. It improves long-range structural understanding as
+model scale grows and is the default choice for embeddings, pseudo-log-likelihood,
+and mutation-effect scoring.
 
-### Option 1: Modal
-```bash
-cd biomodals
-modal run modal_esm2_predict_masked.py \
-  --input-faa sequences.fasta \
-  --out-dir embeddings/
-```
-
-**GPU**: A10G (24GB) | **Timeout**: 300s default
-
-### Option 2: Python API (recommended)
+### Python (Hugging Face)
 ```python
+from transformers import AutoModelForMaskedLM, AutoTokenizer
 import torch
-import esm
 
-# Load model
-model, alphabet = esm.pretrained.esm2_t33_650M_UR50D()
-batch_converter = alphabet.get_batch_converter()
-model = model.eval().cuda()
+model_id = "biohub/ESMC-6B"
+tok = AutoTokenizer.from_pretrained(model_id)
+model = AutoModelForMaskedLM.from_pretrained(
+    model_id, output_hidden_states=True, torch_dtype=torch.bfloat16
+).eval().cuda()
 
-# Process sequences
-data = [("seq1", "MKTAYIAKQRQISFVK...")]
-batch_labels, batch_strs, batch_tokens = batch_converter(data)
-
+batch = tok(["MKTAYIAKQRQISFVK..."], return_tensors="pt").to("cuda")
 with torch.no_grad():
-    results = model(batch_tokens.cuda(), repr_layers=[33])
+    out = model(**batch)
 
-# Get embeddings
-embeddings = results["representations"][33]
+logits = out.logits                      # for PLL / mutation scoring
+embeddings = out.hidden_states[-1]       # per-residue representations
 ```
 
-## Key parameters
+### Hosted API
+```python
+from esm.sdk import client
 
-### ESM2 Models
-
-| Model | Parameters | Speed | Quality |
-|-------|------------|-------|---------|
-| esm2_t6_8M | 8M | Fastest | Fast screening |
-| esm2_t12_35M | 35M | Fast | Good |
-| esm2_t33_650M | 650M | Medium | Better |
-| esm2_t36_3B | 3B | Slow | Best |
-
-## Output format
-
-```
-embeddings/
-├── embeddings.npy       # (N, 1280) array
-├── pll_scores.csv       # PLL for each sequence
-└── metadata.json        # Sequence info
+model = client("esmc-600m-2024-12", url="https://biohub.ai")
 ```
 
-## Sample output
+ESMC-6B has open weights; `esmc-600m` is the smaller API model. For mutation
+scoring and fine-tuning, see the `esmc_mutation_scoring` and `esmc_finetune`
+notebooks under [cookbook/tutorials](https://github.com/Biohub/esm/tree/main/cookbook/tutorials).
 
-### Successful run
-```
-$ modal run modal_esm2_predict_masked.py --input-faa designs.fasta
-[INFO] Loading ESM2-650M model...
-[INFO] Processing 100 sequences...
-[INFO] Computing pseudo-log-likelihood...
+## ESMFold2: complex structure prediction
 
-embeddings/pll_scores.csv:
-sequence_id,pll,pll_normalized,length
-design_0,-0.82,0.15,78
-design_1,-0.95,0.08,85
-design_2,-1.23,-0.12,72
-...
+ESMFold2 is built on ESMC-6B with a diffusion structure head. Unlike the original
+ESMFold, it predicts complexes (protein, DNA, ligand, and modified residues), takes
+an optional MSA, and has a single-sequence fast mode for high-throughput screening.
+It is validated for protein-protein interaction design and leads DockQ pass-rate on
+Foldbench protein-protein and antibody-antigen complexes.
 
-Summary:
-  Mean PLL: -0.91
-  Sequences with PLL > 0: 42/100 (42%)
+### Modal
+```bash
+# https://modal.com/docs/examples/esmfold2
+modal run esmfold2.py --sequence "MKTAYIAKQRQISFVK..."
 ```
 
-**What good output looks like:**
-- PLL_normalized: > 0.0 (more natural-like)
-- Embeddings shape: (N, 1280) for 650M model
-- Higher PLL = more natural sequence
+### Python (Hugging Face)
+```python
+from esm.models.esmfold2 import ESMFold2
 
-## Decision tree
+model = ESMFold2.from_pretrained("biohub/ESMFold2").eval().cuda()
+out = model.fold(sequences=["BINDER_SEQ", "TARGET_SEQ"])   # outputs CIF + pLDDT/pTM/ipTM
+```
 
+Use the `esmfold2-fast-2026-05` variant in single-sequence mode for an order of
+magnitude speedup when screening many designs. ESMFold2 is one option for complex
+validation alongside `boltz` and `chai`; ranking a shortlist across more than one
+predictor is more reliable than trusting a single model.
+
+## Binder design by inverting ESMFold2
+
+The [binder_design cookbook](https://github.com/Biohub/esm/blob/main/cookbook/tutorials/binder_design.ipynb)
+runs gradient optimization through ESMFold2 (a BindCraft-style loop), with an ESMC
+language-model term for sequence plausibility. The published protocol is validated
+in the lab to nanomolar affinity across five targets and supports both minibinders
+and antibody-derived scFvs with framework scaffolds.
+
+- Prompt positions to design with `#`; fix the rest as amino acids.
+- Optimize a soft sequence with Adam (about 150 steps, temperature anneal).
+- Rank candidates by ipTM, filter minibinders to pI below 6, then validate the top
+  shortlist with `boltz` or `chai` and rank with `ipsae`.
+
+For a more general framework that composes ESMFold2 with other predictors in one
+objective, use the `mosaic` skill.
+
+## ESM2 (legacy)
+
+ESM2 still works well for quick embeddings and PLL when ESMC-6B is too large for the
+available GPU.
+
+```python
+import torch, esm
+model, alphabet = esm.pretrained.esm2_t33_650M_UR50D()
+bc = alphabet.get_batch_converter()
+model = model.eval().cuda()
+_, _, toks = bc([("seq1", "MKTAYIAKQRQISFVK...")])
+with torch.no_grad():
+    rep = model(toks.cuda(), repr_layers=[33])["representations"][33]
 ```
-Should I use ESM2?
-│
-├─ What do you need?
-│  ├─ Sequence plausibility score → ESM2 PLL ✓
-│  ├─ Embeddings for clustering → ESM2 ✓
-│  ├─ Variant effect prediction → ESM2 ✓
-│  └─ Structure prediction → Use ESMFold
-│
-├─ What model size?
-│  ├─ Fast screening → esm2_t12_35M
-│  ├─ Standard use → esm2_t33_650M ✓
-│  └─ Best quality → esm2_t36_3B
-│
-└─ Use case?
-   ├─ QC filtering → PLL > 0.0 threshold
-   ├─ Diversity analysis → Mean-pooled embeddings
-   └─ Mutation scanning → Per-position log-odds
-```
+
+| Model | Parameters | Use |
+|-------|------------|-----|
+| esm2_t12_35M | 35M | Fast screening |
+| esm2_t33_650M | 650M | Standard embeddings/PLL |
+| esm2_t36_3B | 3B | Highest-quality ESM2 |
 
 ## PLL interpretation
 
+PLL (pseudo-log-likelihood) scores how natural a sequence looks to the model. Higher
+is more natural. Designed sequences often score lower than natural ones, so treat PLL
+as a soft filter, not a hard cutoff.
+
 | Normalized PLL | Interpretation |
 |----------------|----------------|
-| > 0.2 | Very natural sequence |
-| 0.0 - 0.2 | Good, natural-like |
-| -0.5 - 0.0 | Acceptable |
+| > 0.2 | Very natural |
+| 0.0 to 0.2 | Natural-like |
+| -0.5 to 0.0 | Acceptable |
 | < -0.5 | May be unnatural |
-
-## Typical performance
-
-| Campaign Size | Time (A10G) | Cost (Modal) | Notes |
-|---------------|-------------|--------------|-------|
-| 100 sequences | 5-10 min | ~$1 | Quick screen |
-| 1000 sequences | 30-60 min | ~$5 | Standard |
-| 5000 sequences | 2-3h | ~$20 | Large batch |
-
-**Throughput**: ~100-200 sequences/minute with 650M model.
-
----
-
-## Verify
-
-```bash
-wc -l embeddings/pll_scores.csv  # Should match input + 1 (header)
-```
-
----
 
 ## Troubleshooting
 
-**OOM errors**: Use smaller model or batch sequences
-**Slow processing**: Use esm2_t12_35M for speed
-**Low PLL scores**: May indicate unusual/designed sequences
-
-### Error interpretation
-
-| Error | Cause | Fix |
+| Issue | Cause | Fix |
 |-------|-------|-----|
-| `RuntimeError: CUDA out of memory` | Sequence too long or large batch | Reduce batch size |
-| `KeyError: representation` | Wrong layer requested | Use layer 33 for 650M model |
-| `ValueError: sequence` | Invalid amino acid | Check for non-standard AAs |
+| CUDA out of memory | ESMC-6B / ESMFold2 too large | Use ESMC-600m API, ESM2, or an 80GB GPU |
+| Wrong layer for embeddings | Layer index mismatch | Use the last hidden state (layer 33 for ESM2-650M) |
+| Invalid amino acid | Non-standard residue | Check for non-canonical characters |
+| Slow ESMFold2 on many designs | Full MSA mode | Use `esmfold2-fast-2026-05` single-sequence mode |
 
 ---
 
-**Next**: Structure prediction with `chai` or `boltz` → `protein-qc` for filtering.
+**Next**: Validate structures with `boltz` or `chai`, rank with `ipsae`, then filter
+with `protein-qc`.

--- a/skills/esm/SKILL.md
+++ b/skills/esm/SKILL.md
@@ -75,11 +75,16 @@ logits = out.logits                      # for PLL / mutation scoring
 embeddings = out.hidden_states[-1]       # per-residue representations
 ```
 
+Install the package with `pip install esm@git+https://github.com/Biohub/esm.git@main`.
+
 ### Hosted API
 ```python
-from esm.sdk import client
+from esm.sdk import esmc_client
+from esm.sdk.api import ESMProtein, LogitsConfig
 
-model = client("esmc-600m-2024-12", url="https://biohub.ai")
+model = esmc_client(model="esmc-600m-2024-12", url="https://biohub.ai", token="<API token>")
+tensor = model.encode(ESMProtein(sequence="MKTAYIAKQRQISFVK..."))
+out = model.logits(tensor, LogitsConfig(sequence=True, return_embeddings=True))
 ```
 
 ESMC-6B has open weights; `esmc-600m` is the smaller API model. For mutation
@@ -94,40 +99,55 @@ an optional MSA, and has a single-sequence fast mode for high-throughput screeni
 It is validated for protein-protein interaction design and leads DockQ pass-rate on
 Foldbench protein-protein and antibody-antigen complexes.
 
-### Modal
+### Modal (biomodals)
 ```bash
-# https://modal.com/docs/examples/esmfold2
-modal run esmfold2.py --sequence "MKTAYIAKQRQISFVK..."
+printf '>protein|A\nMKTAYIAKQRQISFVK...\n' > target.faa
+uv run --with modal modal run modal_esmfold2.py --input-faa target.faa
 ```
 
-### Python (Hugging Face)
+The FASTA header tags `protein|`, `dna|`, `rna|`, and `ligand|` (SMILES) let you fold
+complexes. GPU defaults to A100-40GB (set with `MODAL_GPU`).
+
+### Python (local weights)
 ```python
-from esm.models.esmfold2 import ESMFold2
+from transformers.models.esmfold2.modeling_esmfold2 import ESMFold2Model
+from esm.models.esmfold2 import ProteinInput, StructurePredictionInput, ESMFold2InputBuilder
 
-model = ESMFold2.from_pretrained("biohub/ESMFold2").eval().cuda()
-out = model.fold(sequences=["BINDER_SEQ", "TARGET_SEQ"])   # outputs CIF + pLDDT/pTM/ipTM
+model = ESMFold2Model.from_pretrained("biohub/ESMFold2").cuda().eval()
+spi = StructurePredictionInput(sequences=[ProteinInput(id="A", sequence="BINDER_SEQ")])
+result = ESMFold2InputBuilder().fold(model, spi, num_loops=20, num_sampling_steps=100)
+# result.plddt, result.ptm, result.iptm, result.complex.to_mmcif()
 ```
 
-Use the `esmfold2-fast-2026-05` variant in single-sequence mode for an order of
-magnitude speedup when screening many designs. ESMFold2 is one option for complex
-validation alongside `boltz` and `chai`; ranking a shortlist across more than one
-predictor is more reliable than trusting a single model.
+For single-sequence high-throughput folding, the fast variant is the SDK model string
+`esmfold2-fast-2026-05` (HF repo `biohub/ESMFold2-Fast`). ESMFold2 is one option for
+complex validation alongside `boltz` and `chai`; ranking a shortlist across more than
+one predictor is more reliable than trusting a single model.
 
 ## Binder design by inverting ESMFold2
 
 The [binder_design cookbook](https://github.com/Biohub/esm/blob/main/cookbook/tutorials/binder_design.ipynb)
-runs gradient optimization through ESMFold2 (a BindCraft-style loop), with an ESMC
-language-model term for sequence plausibility. The published protocol is validated
-in the lab to nanomolar affinity across five targets and supports both minibinders
-and antibody-derived scFvs with framework scaffolds.
+runs gradient optimization through ESMFold2 (a BindCraft-style loop) with an ESMC
+language-model term for sequence plausibility. The published protocol is validated in
+the lab to nanomolar affinity across five targets and supports both minibinders and
+antibody-derived scFvs with framework scaffolds.
 
-- Prompt positions to design with `#`; fix the rest as amino acids.
-- Optimize a soft sequence with Adam (about 150 steps, temperature anneal).
+biomodals wraps this as `modal_esmfold2_binder_design.py`:
+
+```bash
+uv run --with modal modal run modal_esmfold2_binder_design.py \
+  --target-name pd-l1 --binder-name minibinder
+```
+
+- Targets: presets `cd45, ctla4, egfr, pd-l1, pdgfr`, or pass `--target-sequence`.
+- Binders: presets `minibinder` and antibody frameworks (for example
+  `trastuzumab_framework_vhvl`), or pass `--binder-sequence` with `#` for designable
+  positions. Use `--is-antibody` for scFv designs.
 - Rank candidates by ipTM, filter minibinders to pI below 6, then validate the top
   shortlist with `boltz` or `chai` and rank with `ipsae`.
 
-For a more general framework that composes ESMFold2 with other predictors in one
-objective, use the `mosaic` skill.
+For a framework that composes ESMFold2 with other predictors in one objective, use the
+`mosaic` skill.
 
 ## ESM2 (legacy)
 

--- a/skills/foldseek/SKILL.md
+++ b/skills/foldseek/SKILL.md
@@ -73,15 +73,15 @@ def foldseek_search(query_pdb, database, output="results.m8"):
 | `--min-seq-id` | 0.0 | Minimum sequence identity |
 | `-e` | 0.001 | E-value threshold |
 | `--alignment-type` | 2 | 0=3Di, 1=TM, 2=3Di+AA |
-| `--max-seqs` | 300 | Max hits to pass through prefilter; reducing this affects sensitivity |
+| `--max-seqs` | 1000 | Max hits to pass through prefilter; reducing this affects sensitivity |
 
 ## Databases
 
 | Database | Description | Size |
 |----------|-------------|------|
-| `pdb100` | PDB clustered at 100% | ~200K structures |
-| `afdb50` | AlphaFold DB at 50% | ~67M structures |
-| `swissprot` | SwissProt structures | ~500K structures |
+| `pdb100` | PDB chains | ~340K structures |
+| `afdb50` | AlphaFold DB clustered at 50% sequence identity | ~53M structures |
+| `swissprot` | SwissProt structures | ~540K structures |
 | `cath50` | CATH domains | ~50K domains |
 
 ## Output format
@@ -98,17 +98,13 @@ query   2def_B          72.1    115     1e-32   145.2
 ### Successful run
 ```
 $ foldseek easy-search query.pdb pdb100 results.m8 tmp/
-[INFO] Loading database: pdb100 (194,527 entries)
-[INFO] Searching...
-[INFO] Found 127 hits
-
-Top 5 hits:
-1. 1abc_A - 85.2% identity, E=1e-45
-2. 2def_B - 72.1% identity, E=1e-32
-3. 3ghi_C - 68.5% identity, E=1e-28
-4. 4jkl_A - 55.3% identity, E=1e-18
-5. 5mno_B - 42.1% identity, E=1e-10
+# results.m8 columns: query target pident alnlen mismatch gapopen qstart qend tstart tend evalue bits
+query   1abc_A  85.2  120  ...  1e-45  180.5
+query   2def_B  72.1  115  ...  1e-32  145.2
 ```
+
+Hit identities and E-values above are placeholders; foldseek does not print the
+`[INFO]` lines shown by some other tools.
 
 ## Decision tree
 

--- a/skills/germinal/SKILL.md
+++ b/skills/germinal/SKILL.md
@@ -76,6 +76,11 @@ Antibody-format binder?
 For VHH nanobodies, biomodals also has `modal_mber.py` (mBER) and `modal_iggm.py`
 (IgGM) as alternatives.
 
+## Cost
+
+Adaptyv's own tests of these models showed Germinal costing about $1.60 per accepted
+design, averaged across 7 targets.
+
 ## Troubleshooting
 
 | Issue | Cause | Fix |

--- a/skills/germinal/SKILL.md
+++ b/skills/germinal/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: germinal
+description: >
+  De novo antibody and nanobody (VHH) design with Germinal. Use this skill when:
+  (1) Designing epitope-targeted nanobodies or scFvs, (2) Needing CDR design on a
+  fixed framework, (3) Working on antibody-format binders rather than miniproteins.
+
+  For miniprotein binders, use binder-design (BoltzGen, BindCraft, RFdiffusion, Mosaic).
+  For structure validation, use boltz or chai.
+license: MIT
+category: design-tools
+tags: [antibody, nanobody, vhh, scfv, binder]
+biomodals_script: modal_germinal.py
+---
+
+# Germinal Antibody and Nanobody Design
+
+[Germinal](https://github.com/SantiagoMille/germinal) is an open pipeline for
+epitope-targeted de novo antibody and nanobody design. It hallucinates CDRs on a
+fixed framework, designs sequences with AbMPNN, and cofolds with a structure
+predictor (it downloads AlphaFold-Multimer params). Runnable through biomodals.
+
+The biomodals author notes Germinal is finicky and suggests BoltzGen for general
+binder design; treat Germinal as the antibody-format option, not a default.
+
+## Prerequisites
+
+| Requirement | Value |
+|-------------|-------|
+| Runner | Modal (biomodals) |
+| GPU | H100 (default; `GPU` env var) |
+| Setup | See [Getting started](../../docs/getting-started.md) |
+
+## How to run
+
+```bash
+git clone https://github.com/hgbrian/biomodals && cd biomodals
+
+uv run --with modal --with PyYAML modal run modal_germinal.py \
+  --target-yaml target_example.yaml \
+  --max-trajectories 1 \
+  --max-passing-designs 1
+```
+
+## Key parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--target-yaml` | required | Target config (target_name, target_pdb_path, target_chain, binder_chain, target_hotspots, length) |
+| `--run-type` | `vhh` | `vhh` (nanobody) or `scfv` |
+| `--max-trajectories` | 100 | Trajectories to run |
+| `--max-passing-designs` | 10 | Stop after this many passing designs |
+| `--out-dir` | `./out/germinal` | Output directory |
+
+## Target YAML
+
+```yaml
+target_name: PDL1
+target_pdb_path: target.pdb
+target_chain: A
+binder_chain: B
+target_hotspots: "45,67,89"
+length: 120
+```
+
+## Decision tree
+
+```
+Antibody-format binder?
+│
+├─ Nanobody / VHH → germinal (run-type vhh) or mber
+├─ scFv → germinal (run-type scfv)
+└─ Miniprotein (not antibody) → binder-design (boltzgen, bindcraft, mosaic)
+```
+
+For VHH nanobodies, biomodals also has `modal_mber.py` (mBER) and `modal_iggm.py`
+(IgGM) as alternatives.
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Pipeline fails early | Missing PyYAML | Add `--with PyYAML` to the invocation |
+| No passing designs | Hard epitope or low budget | Raise `--max-trajectories` |
+| OOM | Large target | Use the default H100 or trim the target |
+
+---
+
+**Next**: Validate with `boltz` or `chai`, rank with `ipsae`, filter with `protein-qc`.

--- a/skills/ipsae/SKILL.md
+++ b/skills/ipsae/SKILL.md
@@ -27,9 +27,9 @@ tags: [ranking, scoring, binding]
 
 ## Overview
 
-ipSAE (interprotein Score from Aligned Errors) is a scoring function for ranking protein-protein interactions predicted by AlphaFold2, AlphaFold3, and Boltz1. It outperforms ipTM and iPAE for binder design ranking with **1.4x higher precision** in identifying true binders.
+ipSAE (interprotein Score from Aligned Errors) is a scoring function for ranking protein-protein interactions predicted by AlphaFold2, AlphaFold3, and Boltz1. It separates true from false predicted complexes more reliably than ipTM, which dilutes interface confidence across disordered or accessory regions. In a separate binder meta-analysis (Overath et al. 2025), AF3 ipSAE_min gave a 1.4-fold gain in average precision over the ipAE score that RFdiffusion pipelines commonly filter on.
 
-**Paper**: [What's wrong with AlphaFold's ipTM score](https://www.biorxiv.org/content/10.1101/2025.02.10.637595v2)
+**Paper**: Dunbrack, "Rēs ipSAE loquuntur: What's wrong with AlphaFold's ipTM score and how to fix it", [bioRxiv 2025.02.10.637595](https://www.biorxiv.org/content/10.1101/2025.02.10.637595v2)
 
 ## How to run
 

--- a/skills/ligandmpnn/SKILL.md
+++ b/skills/ligandmpnn/SKILL.md
@@ -34,13 +34,13 @@ biomodals_script: modal_ligandmpnn.py
 ### Option 1: Modal (recommended)
 ```bash
 cd biomodals
+# modal_ligandmpnn.py takes --input-pdb; LigandMPNN run.py args go in --params-str
 modal run modal_ligandmpnn.py \
-  --pdb-path protein_ligand.pdb \
-  --num-seq-per-target 16 \
-  --sampling-temp 0.1
+  --input-pdb protein_ligand.pdb \
+  --params-str "--model_type ligand_mpnn --number_of_batches 16 --temperature 0.1"
 ```
 
-**GPU**: T4 (16GB) | **Timeout**: 600s default
+**GPU**: A10G default | **Timeout**: 900s default
 
 ### Option 2: Local installation
 ```bash
@@ -48,19 +48,23 @@ git clone https://github.com/dauparas/LigandMPNN.git
 cd LigandMPNN
 
 python run.py \
+  --model_type ligand_mpnn \
   --pdb_path protein_ligand.pdb \
   --out_folder output/ \
-  --num_seq_per_target 16
+  --number_of_batches 16 \
+  --temperature 0.1
 ```
 
-## Key parameters
+## Key parameters (LigandMPNN run.py)
 
-| Parameter | Default | Range | Description |
-|-----------|---------|-------|-------------|
-| `--pdb_path` | required | path | PDB with ligand |
-| `--num_seq_per_target` | 1 | 1-1000 | Sequences per structure |
-| `--sampling_temp` | "0.1" | "0.0001-1.0" | Temperature (string!) |
-| `--ligand_mpnn_use_side_chain_context` | true | bool | Use ligand context |
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--pdb_path` | required | PDB with ligand |
+| `--model_type` | `protein_mpnn` | `ligand_mpnn`, `soluble_mpnn`, etc. |
+| `--temperature` | 0.1 | Sampling temperature |
+| `--number_of_batches` | 1 | Batches (sequences = batch_size x batches) |
+| `--batch_size` | 1 | Sequences per batch |
+| `--ligand_mpnn_use_side_chain_context` | 0 | Use ligand side-chain context |
 
 ## Ligand Specification
 

--- a/skills/ligandmpnn/SKILL.md
+++ b/skills/ligandmpnn/SKILL.md
@@ -29,7 +29,7 @@ biomodals_script: modal_ligandmpnn.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal (recommended)
 ```bash

--- a/skills/mosaic/SKILL.md
+++ b/skills/mosaic/SKILL.md
@@ -148,6 +148,12 @@ Should I use Mosaic?
 └─ Want backbone-only diversity?                    → rfdiffusion + proteinmpnn
 ```
 
+## Cost
+
+Adaptyv's own tests of these models showed Mosaic costing about $0.55 per accepted
+design, averaged across 7 targets, among the cheapest per design of the methods tested.
+That is compute only; the setup and tuning effort is the real cost of using Mosaic.
+
 ## Troubleshooting
 
 | Issue | Cause | Fix |

--- a/skills/mosaic/SKILL.md
+++ b/skills/mosaic/SKILL.md
@@ -45,11 +45,18 @@ JIT compilation makes the first call to any loss slow; later calls are fast.
 
 ## Install
 
+Mosaic runs locally on a JAX GPU or TPU build. It has no CLI and no Modal
+integration; you drive it through the marimo notebooks or the Python API.
+
 ```bash
 git clone https://github.com/escalante-bio/mosaic && cd mosaic
-uv sync --group jax-cuda
+uv sync --group jax-cuda      # or --group jax-tpu / --group jax-cpu
+uv add jax[cuda12]            # may be needed for a GPU build
 uv run marimo edit examples/example_notebook.py
 ```
+
+Ready-made examples include `esmfold_minibinder.py`, `esmfold_vhh.py`,
+`boltzgen_pipeline.py`, and `batched_protenix.py`.
 
 ## Core idea
 
@@ -99,17 +106,28 @@ A reasonable `simplex_APGM` step size is about `0.1 * sqrt(binder_length)`.
 
 The published [Nipah competition recipe](https://blog.escalante.bio/180-lines-of-code-to-win-the-in-silico-portion-of-the-adaptyv-nipah-binding-competition/)
 optimizes a design loss on Boltz-2, then ranks candidates with a separate
-multi-sample loss built from ipTM and ipSAE.
+multi-sample loss built from ipTM and ipSAE. The multi-sample loss is a method on the
+Boltz2 model, not a free function:
 
 ```python
-ranking_loss = folder.build_multisample_loss(
+from mosaic.models.boltz2 import Boltz2
+
+boltz2 = Boltz2()
+ranking_loss = boltz2.build_multisample_loss(
     loss=1.00 * sp.IPTMLoss()
     + 0.5 * sp.TargetBinderIPSAE()
     + 0.5 * sp.BinderTargetIPSAE(),
+    features=design_features,
     num_samples=6,
     recycling_steps=3,
 )
 ```
+
+On the Adaptyv Nipah de novo target, this recipe produced 8 binders out of 9 tested
+designs (about 25 nM), the highest hit-rate of any method on that target in the public
+results. That is a small, expert-tuned sample on one hard target, not a guarantee
+across targets, so treat Mosaic as a high-ceiling option that rewards careful objective
+design rather than a turnkey default.
 
 Two practices from that work are worth carrying over:
 

--- a/skills/mosaic/SKILL.md
+++ b/skills/mosaic/SKILL.md
@@ -124,8 +124,8 @@ ranking_loss = boltz2.build_multisample_loss(
 ```
 
 On the Adaptyv Nipah de novo target, this recipe produced 8 binders out of 9 tested
-designs (about 25 nM), the highest hit-rate of any method on that target in the public
-results. That is a small, expert-tuned sample on one hard target, not a guarantee
+designs at nanomolar affinity, the highest hit-rate of any method on that target in the
+public results. That is a small, expert-tuned sample on one hard target, not a guarantee
 across targets, so treat Mosaic as a high-ceiling option that rewards careful objective
 design rather than a turnkey default.
 

--- a/skills/mosaic/SKILL.md
+++ b/skills/mosaic/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: mosaic
+description: >
+  Multi-objective, gradient-based protein binder design with Mosaic. Use this
+  skill when: (1) Composing several structure or sequence models into one design
+  objective, (2) Optimizing binders against a custom loss rather than a fixed
+  pipeline, (3) Wanting gradient descent over sequence space in the style of
+  ColabDesign, RSO, or BindCraft but with interchangeable predictors, (4) Letting
+  the optimizer choose the epitope instead of fixing hotspots.
+
+  For an end-to-end binder pipeline with default filters, use bindcraft.
+  For all-atom diffusion design, use boltzgen.
+  For backbone-only generation, use rfdiffusion.
+license: MIT
+category: design-tools
+tags: [design, gradient-optimization, multi-objective, jax, binder]
+---
+
+# Mosaic Multi-Objective Design
+
+[Mosaic](https://github.com/escalante-bio/mosaic) (Escalante Bio) is a JAX framework
+for "functional, multi-objective protein design using continuous relaxation." It
+optimizes a soft sequence by gradient descent over a continuous relaxation of
+sequence space, in the lineage of ColabDesign, RSO, and BindCraft, with one key
+difference: it composes multiple learned objectives from different models in a single
+differentiable loss.
+
+## When Mosaic fits
+
+Mosaic is a framework for custom objectives, not a one-click method. The README is
+explicit: it "may require substantial hand-holding (tuning learning rates, etc),
+often produces proteins that fail simple in-silico tests, [and] should be combined
+with standard filtering methods." Reach for it when a fixed pipeline cannot express
+the objective you need. For a turnkey binder run, use `bindcraft` instead.
+
+## Prerequisites
+
+| Requirement | Minimum | Recommended |
+|-------------|---------|-------------|
+| Python | 3.11+ | 3.11 |
+| Framework | JAX with CUDA or TPU | JAX CUDA 12 |
+| GPU VRAM | 24GB | 48GB+ (depends on predictors used) |
+
+JIT compilation makes the first call to any loss slow; later calls are fast.
+
+## Install
+
+```bash
+git clone https://github.com/escalante-bio/mosaic && cd mosaic
+uv sync --group jax-cuda
+uv run marimo edit examples/example_notebook.py
+```
+
+## Core idea
+
+A design objective is built from `LossTerm` objects that you add and scale with plain
+Python arithmetic, then hand to an optimizer.
+
+```python
+import mosaic.losses.structure_prediction as sp
+
+# Compose a loss from interface, confidence, and inverse-folding terms
+design_loss = (
+    sp.BinderTargetContact()
+    + sp.WithinBinderContact()
+    + 0.05 * sp.TargetBinderPAE()
+    + 0.05 * sp.BinderTargetPAE()
+    + 0.025 * sp.IPTMLoss()
+    + 0.1 * sp.PLDDTLoss()
+)
+```
+
+Loss terms can wrap one model used several ways (for example a structure predictor
+scoring both the binder-target complex and the binder as a monomer). Composing
+different architectures also lowers the chance of finding adversarial sequences that
+fool a single predictor.
+
+### What you can compose
+
+| Category | Options |
+|----------|---------|
+| Structure predictors | AF2, Boltz-1, Boltz-2, Protenix, OpenFold3, ESMFold2 |
+| Generative / design | BoltzGen, Proteina-Complexa |
+| Inverse folding | ProteinMPNN, SolubleMPNN, AbMPNN |
+| Language models | ESM-2, ESM-C, AbLang, trigram |
+| Property heads | Stability (megascale-trained) |
+
+### Optimizers
+
+| Optimizer | Use |
+|-----------|-----|
+| `simplex_APGM` | Default; proximal gradient / mirror descent on the probability simplex |
+| `batched_simplex_APGM` | The same, vmapped over many designs |
+| `gradient_MCMC` | Discrete moves for fine-tuning a sequence |
+
+A reasonable `simplex_APGM` step size is about `0.1 * sqrt(binder_length)`.
+
+## Worked example: ranking with ipSAE
+
+The published [Nipah competition recipe](https://blog.escalante.bio/180-lines-of-code-to-win-the-in-silico-portion-of-the-adaptyv-nipah-binding-competition/)
+optimizes a design loss on Boltz-2, then ranks candidates with a separate
+multi-sample loss built from ipTM and ipSAE.
+
+```python
+ranking_loss = folder.build_multisample_loss(
+    loss=1.00 * sp.IPTMLoss()
+    + 0.5 * sp.TargetBinderIPSAE()
+    + 0.5 * sp.BinderTargetIPSAE(),
+    num_samples=6,
+    recycling_steps=3,
+)
+```
+
+Two practices from that work are worth carrying over:
+
+- **Let the optimizer choose the epitope.** Asking for a binder, without fixing
+  hotspots, can find a better interface than a manually chosen one.
+- **Match filter stringency to assay throughput.** With high-throughput testing,
+  filter lightly to keep diversity rather than applying heavy consensus filters that
+  can reject good binders.
+
+## Decision tree
+
+```
+Should I use Mosaic?
+│
+├─ Need a custom objective across multiple models? → Mosaic
+├─ Want one-click binders with default filters?    → bindcraft
+├─ Want all-atom diffusion design?                  → boltzgen
+└─ Want backbone-only diversity?                    → rfdiffusion + proteinmpnn
+```
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Designs fail simple in-silico checks | Under-constrained objective | Add inverse-folding and confidence terms; filter with `protein-qc` |
+| Optimization unstable | Step size too large | Lower the `simplex_APGM` step size |
+| First call very slow | JIT compilation | Expected; reuse the compiled loss across designs |
+| OOM with large predictors | Several models in one loss | Use smaller predictors or a larger GPU |
+
+---
+
+**Next**: Validate designs with `boltz` or `chai`, rank with `ipsae`, then filter
+with `protein-qc`.

--- a/skills/protein-design-workflow/SKILL.md
+++ b/skills/protein-design-workflow/SKILL.md
@@ -71,9 +71,9 @@ python run_inference.py \
 ### Option B: BindCraft (end-to-end)
 ```bash
 modal run modal_bindcraft.py \
-  --target-pdb target_prepared.pdb \
-  --hotspots "A45,A67,A89" \
-  --num-designs 100
+  --input-pdb target_prepared.pdb \
+  --target-hotspot-residues "45,67,89" \
+  --number-of-final-designs 100
 ```
 
 **Output**: 100-500 backbone PDBs
@@ -84,9 +84,8 @@ modal run modal_bindcraft.py \
 ```bash
 for backbone in backbones/*.pdb; do
   modal run modal_ligandmpnn.py \
-    --pdb-path "$backbone" \
-    --num-seq-per-target 8 \
-    --sampling-temp 0.1
+    --input-pdb "$backbone" \
+    --params-str "--number_of_batches 8 --temperature 0.1"
 done
 ```
 
@@ -100,7 +99,7 @@ done
 # binder:target format for multimer
 
 modal run modal_alphafold.py \
-  --input-faa all_sequences.fasta \
+  --input-fasta all_sequences.fasta \
   --out-dir predictions/
 ```
 
@@ -145,7 +144,7 @@ top_designs = filtered.nlargest(50, 'score')
 |-------|-----|-------------------|
 | RFdiffusion | A10G | 30 min |
 | ProteinMPNN | T4 | 15 min |
-| ColabFold | A100 | 4-8 hours |
+| Chai / AlphaFold | A100 | 4-8 hours |
 | Filtering | CPU | 15 min |
 
 ### Total timeline
@@ -189,7 +188,7 @@ top_designs = filtered.nlargest(50, 'score')
 
 ### Multi-tool combination
 1. RFdiffusion for initial backbones
-2. ColabDesign for refinement
+2. Mosaic for gradient-based refinement
 3. ProteinMPNN diversification
 4. AF2 final validation
 

--- a/skills/protein-design-workflow/SKILL.md
+++ b/skills/protein-design-workflow/SKILL.md
@@ -60,11 +60,12 @@ curl -o target.pdb "https://files.rcsb.org/download/XXXX.pdb"
 
 ### Option A: RFdiffusion (diverse exploration)
 ```bash
-modal run modal_rfdiffusion.py \
-  --pdb target_prepared.pdb \
-  --contigs "A1-150/0 70-100" \
-  --hotspot "A45,A67,A89" \
-  --num-designs 500
+# RFdiffusion runs from the official repo, not biomodals
+python run_inference.py \
+  inference.input_pdb=target_prepared.pdb \
+  contigmap.contigs=[A1-150/0 70-100] \
+  ppi.hotspot_res=[A45,A67,A89] \
+  inference.num_designs=500
 ```
 
 ### Option B: BindCraft (end-to-end)
@@ -82,7 +83,7 @@ modal run modal_bindcraft.py \
 ### For RFdiffusion backbones
 ```bash
 for backbone in backbones/*.pdb; do
-  modal run modal_proteinmpnn.py \
+  modal run modal_ligandmpnn.py \
     --pdb-path "$backbone" \
     --num-seq-per-target 8 \
     --sampling-temp 0.1
@@ -98,7 +99,7 @@ done
 # Prepare FASTA with binder + target
 # binder:target format for multimer
 
-modal run modal_colabfold.py \
+modal run modal_alphafold.py \
   --input-faa all_sequences.fasta \
   --out-dir predictions/
 ```

--- a/skills/protein-design-workflow/references/standard-pipeline.md
+++ b/skills/protein-design-workflow/references/standard-pipeline.md
@@ -49,11 +49,12 @@ io.save('target_chain_A.pdb', ChainSelect())
 
 ### Option A: RFdiffusion (Diverse Exploration)
 ```bash
-modal run modal_rfdiffusion.py \
-    --pdb target_prepared.pdb \
-    --contigs "A1-150/0 70-100" \
-    --hotspot "A45,A67,A89" \
-    --num-designs 500
+# RFdiffusion runs from the official repo, not biomodals
+python run_inference.py \
+    inference.input_pdb=target_prepared.pdb \
+    contigmap.contigs=[A1-150/0 70-100] \
+    ppi.hotspot_res=[A45,A67,A89] \
+    inference.num_designs=500
 ```
 
 **Output**: 500 backbone PDBs
@@ -76,7 +77,7 @@ modal run modal_bindcraft.py \
 ```bash
 # Batch process all backbones
 for backbone in backbones/*.pdb; do
-    modal run modal_proteinmpnn.py \
+    modal run modal_ligandmpnn.py \
         --pdb-path "$backbone" \
         --num-seq-per-target 8 \
         --sampling-temp 0.1
@@ -99,7 +100,7 @@ def make_complex_fasta(binder_seq, target_seq, output_path):
 
 ### Run validation
 ```bash
-modal run modal_colabfold.py \
+modal run modal_alphafold.py \
     --input-faa all_complexes.fasta \
     --out-dir predictions/
 ```

--- a/skills/protein-design-workflow/references/standard-pipeline.md
+++ b/skills/protein-design-workflow/references/standard-pipeline.md
@@ -62,9 +62,9 @@ python run_inference.py \
 ### Option B: BindCraft (End-to-End)
 ```bash
 modal run modal_bindcraft.py \
-    --target-pdb target_prepared.pdb \
-    --hotspots "A45,A67,A89" \
-    --num-designs 100
+    --input-pdb target_prepared.pdb \
+    --target-hotspot-residues "45,67,89" \
+    --number-of-final-designs 100
 ```
 
 **Output**: 100 designed binders with sequences
@@ -78,9 +78,8 @@ modal run modal_bindcraft.py \
 # Batch process all backbones
 for backbone in backbones/*.pdb; do
     modal run modal_ligandmpnn.py \
-        --pdb-path "$backbone" \
-        --num-seq-per-target 8 \
-        --sampling-temp 0.1
+        --input-pdb "$backbone" \
+        --params-str "--number_of_batches 8 --temperature 0.1"
 done
 ```
 
@@ -101,7 +100,7 @@ def make_complex_fasta(binder_seq, target_seq, output_path):
 ### Run validation
 ```bash
 modal run modal_alphafold.py \
-    --input-faa all_complexes.fasta \
+    --input-fasta all_complexes.fasta \
     --out-dir predictions/
 ```
 
@@ -156,7 +155,7 @@ top_designs = designs.nlargest(100, 'score')
 |-------|-----|-------------------|
 | RFdiffusion | A10G | 2-3 hours |
 | ProteinMPNN | T4 | 1-2 hours |
-| ColabFold | A100 | 12-24 hours |
+| Chai / AlphaFold | A100 | 12-24 hours |
 | Filtering | CPU | 30 min |
 
 **Total**: 16-30 hours for 500 backbone campaign

--- a/skills/protein-qc/SKILL.md
+++ b/skills/protein-qc/SKILL.md
@@ -87,6 +87,9 @@ de novo failure modes:
 
 Both are in the Cao 2022, AlphaProteo, and BindCraft filter sets.
 
+For structure-quality ranking, biomodals also provides `modal_af2rank.py` (AF2Rank),
+which scores how well a design re-predicts from its own structure as a template.
+
 ## Binder ranking (benchmark-backed)
 
 A meta-analysis of 3,766 experimentally tested binders across 15 targets (Overath et
@@ -274,7 +277,7 @@ Low pLDDT across campaign
 │   └── Low scRMSD but low pLDDT: Disordered regions
 │       └── Fix: Check design length, simplify topology
 ├── Try more sequences per backbone
-│   └── modal run modal_proteinmpnn.py --num-seq-per-target 32 --sampling-temp 0.1
+│   └── modal run modal_ligandmpnn.py --num-seq-per-target 32 --sampling-temp 0.1
 ├── Use SolubleMPNN instead of ProteinMPNN
 │   └── Better for expression-optimized sequences
 └── Consider different design tool

--- a/skills/protein-qc/SKILL.md
+++ b/skills/protein-qc/SKILL.md
@@ -51,13 +51,16 @@ Each category has two levels:
 | **Structural** | pLDDT | > 0.85 | > 0.90 | AF2/Chai/Boltz |
 | | pTM | > 0.70 | > 0.80 | AF2/Chai/Boltz |
 | | scRMSD | < 2.0 Å | < 1.5 Å | Design vs pred |
-| **Binding** | ipTM | > 0.50 | > 0.60 | AF2/Chai/Boltz |
+| **Binding** | ipSAE_min | > 0.61 | > 0.70 | AF3/Boltz (see ipsae) |
+| | ipTM | > 0.50 | > 0.60 | AF2/Chai/Boltz |
 | | PAE_interaction | < 12 Å | < 10 Å | AF2/Chai/Boltz |
-| | Shape Comp (SC) | > 0.50 | > 0.60 | PyRosetta |
+| | Shape Comp (SC) | > 0.50 | > 0.62 | PyRosetta |
 | | interface_dG | < -10 | < -15 | PyRosetta |
+| | Interface BUNS | <= 4 | <= 2 | PyRosetta |
 | **Expression** | Instability | < 40 | < 30 | BioPython |
 | | GRAVY | < 0.4 | < 0.2 | BioPython |
 | | ESM2 PLL | > 0.0 | > 0.2 | ESM2 |
+| | Folding ΔG | < -2 kcal/mol | < -4 kcal/mol | SaProtΔG |
 
 ### Design-Level Checks (Expression)
 | Pattern | Risk | Action |
@@ -68,6 +71,82 @@ Each category has two levels:
 | >= 6 hydrophobic run | Aggregation | Redesign |
 
 See: references/binding-qc.md, references/expression-qc.md, references/structural-qc.md
+
+---
+
+## Interface metrics (PyRosetta)
+
+Beyond shape complementarity and interface_dG, two interface metrics catch common
+de novo failure modes:
+
+- **Buried unsatisfied H-bonds (BUNS)**: buried polar atoms making no hydrogen bond.
+  This is a dominant energetic failure mode and is orthogonal to dG and dSASA. Keep
+  interface BUNS at or below 4 (standard) or 2 (stringent).
+- **ContactMolecularSurface**: shape-complementarity-weighted contact area that, unlike
+  dSASA, is not fooled by gappy or holey interfaces. Higher is better.
+
+Both are in the Cao 2022, AlphaProteo, and BindCraft filter sets.
+
+## Binder ranking (benchmark-backed)
+
+A meta-analysis of 3,766 experimentally tested binders across 15 targets (Overath et
+al., bioRxiv 2025, doi:10.1101/2025.08.14.670059) found that AF3 `ipSAE_min` is the
+single best in-silico predictor of binding, and that a simple linear model of three
+features generalizes best across targets. Complexity did not help: gradient-boosted
+and many-feature models did not beat the linear one.
+
+Recommended filtering strategies from that work:
+
+1. Threshold on one of: `AF3 ipSAE_min > 0.61`, or `ipSAE_min × interface_ΔG/ΔSASA <
+   -1.5`, or `LIS × shape_complementarity > 0.42`.
+2. Pre-filter on `shape_complementarity > 0.62` and `RMSD_binder < 3.73` (input vs
+   re-predicted), then take the top-K by `ipSAE_min`.
+
+`ipSAE_min` is the minimum of the two asymmetric ipSAE directions (binder→target and
+target→binder), not the average or max. Use the `ipsae` skill to compute it. Note the
+RMSD_binder filter can be over-restrictive on some targets, so prefer it as a soft
+pre-filter rather than a hard cutoff.
+
+## Stability prediction (small domains)
+
+For small domains (roughly 60 to 100 residues, the minibinder range), absolute folding
+stability can be predicted directly. SaProtΔG (Cho et al., bioRxiv 2026,
+doi:10.64898/2026.05.19.726285) predicts absolute folding ΔG at about 0.8 kcal/mol RMSE
+and improves discrimination of stable versus unstable designed proteins. Use the SaProt
+variant rather than the ESM3 variant for commercial work, since the ESM3 weights are
+non-commercial. Filter for more negative (more stable) ΔG.
+
+## Sequence-liability scan
+
+Implement liability checks directly as motif rules rather than taking an
+antibody-specific dependency. Severity rises with solvent exposure (gate by SASA when a
+structure is available).
+
+```python
+import re
+
+LIABILITIES = {
+    "deamidation":   (r"N[GSNTH]",   "NG/NS high, NN/NT moderate"),
+    "isomerization": (r"D[GSTDH]",   "Asp isomerization"),
+    "N-glycosylation": (r"N[^P][ST]", "NxS/T sequon"),
+    "polybasic":     (r"[KR]{3,}",   "proteolysis / charge patch"),
+    "hydrophobic_run": (r"[AILMFWVY]{6,}", "aggregation"),
+}
+
+def scan_liabilities(seq):
+    hits = {}
+    for name, (pattern, note) in LIABILITIES.items():
+        positions = [m.start() for m in re.finditer(pattern, seq)]
+        if positions:
+            hits[name] = (positions, note)
+    # Unpaired cysteine check
+    if seq.count("C") % 2 == 1:
+        hits["unpaired_cysteine"] = ([seq.index("C")], "odd cysteine count")
+    return hits
+```
+
+Met and Trp oxidation are also liabilities but should be flagged only when the residue
+is solvent-exposed.
 
 ---
 

--- a/skills/protein-qc/SKILL.md
+++ b/skills/protein-qc/SKILL.md
@@ -112,7 +112,7 @@ pre-filter rather than a hard cutoff.
 
 ## Stability prediction (small domains)
 
-For small domains (roughly 60 to 100 residues, the minibinder range), absolute folding
+For small domains (roughly 60 to 80 residues, the minibinder range), absolute folding
 stability can be predicted directly. SaProtΔG (Cho et al., bioRxiv 2026,
 doi:10.64898/2026.05.19.726285) predicts absolute folding ΔG at about 0.8 kcal/mol RMSE
 and improves discrimination of stable versus unstable designed proteins. Use the SaProt
@@ -277,7 +277,7 @@ Low pLDDT across campaign
 │   └── Low scRMSD but low pLDDT: Disordered regions
 │       └── Fix: Check design length, simplify topology
 ├── Try more sequences per backbone
-│   └── modal run modal_ligandmpnn.py --num-seq-per-target 32 --sampling-temp 0.1
+│   └── modal run modal_ligandmpnn.py --input-pdb bb.pdb --params-str "--number_of_batches 32 --temperature 0.1"
 ├── Use SolubleMPNN instead of ProteinMPNN
 │   └── Better for expression-optimized sequences
 └── Consider different design tool
@@ -306,8 +306,8 @@ Low ipTM across campaign
 ```
 Sequences don't specify intended structure
 ├── ProteinMPNN issue
-│   ├── Lower temperature: --sampling-temp 0.1
-│   ├── Increase sequences: --num-seq-per-target 32
+│   ├── Lower temperature: --sampling_temp "0.1"
+│   ├── Increase sequences: --num_seq_per_target 32
 │   └── Check fixed_positions aren't over-constraining
 ├── Backbone geometry issue
 │   ├── Backbones may be unusual/strained

--- a/skills/proteinmpnn/SKILL.md
+++ b/skills/proteinmpnn/SKILL.md
@@ -49,12 +49,15 @@ python protein_mpnn_run.py \
 ### Option 2: Modal (via LigandMPNN wrapper)
 ```bash
 cd biomodals
+# modal_ligandmpnn.py takes --input-pdb and forwards run.py args via --params-str
 modal run modal_ligandmpnn.py \
-  --pdb-path backbone.pdb \
-  --num-seq-per-target 16
+  --input-pdb backbone.pdb \
+  --params-str "--model_type protein_mpnn --number_of_batches 16 --temperature 0.1"
 ```
 
-Note: LigandMPNN includes ProteinMPNN functionality.
+**GPU** (Modal): A10G default | **Timeout**: 900s default
+
+Note: LigandMPNN includes ProteinMPNN functionality (select with `--model_type protein_mpnn`).
 
 ## Config Schema
 

--- a/skills/proteinmpnn/SKILL.md
+++ b/skills/proteinmpnn/SKILL.md
@@ -30,7 +30,7 @@ biomodals_script: modal_ligandmpnn.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Local installation (recommended)
 ```bash

--- a/skills/protenix/SKILL.md
+++ b/skills/protenix/SKILL.md
@@ -16,8 +16,15 @@ biomodals_script: modal_protenix.py
 # Protenix Structure Prediction
 
 [Protenix](https://github.com/bytedance/Protenix) is ByteDance's open PyTorch
-reproduction of AlphaFold3. It is an AF3-class complex predictor, useful next to
-`boltz` and `chai` for cross-checking designed complexes. Runnable through biomodals.
+reproduction of AlphaFold3 (Apache 2.0). It is an AF3-class complex predictor, useful
+next to `boltz` and `chai` for cross-checking designed complexes. Runnable through
+biomodals.
+
+**Use Protenix-v2 for antibody-antigen complexes.** The v2 model (464M params, April
+2026) adds 9 to 13 percentage points of antibody-antigen accuracy over v1 at the
+DockQ > 0.23 threshold and is more sample-efficient (v2 at 5 seeds exceeds v1 at 1000).
+Select it with `--model-name protenix-v2`. For general complexes, the v1 base model is
+fine.
 
 ## Prerequisites
 
@@ -47,6 +54,7 @@ uv run --with modal modal run modal_protenix.py \
 | `--input-faa` | one required | FASTA input (or `--input-json`) |
 | `--seeds` | `42` | Comma-separated seeds |
 | `--use-msa` / `--no-use-msa` | MSA on | Pass `--no-use-msa` for single-sequence |
+| `--model-name` | v1 base | Set `protenix-v2` for antibody-antigen complexes |
 | `--use-mini` | off | Switch to the smaller `protenix_mini` model |
 | `--out-dir` | `./out/protenix` | Output directory |
 
@@ -56,7 +64,8 @@ uv run --with modal modal run modal_protenix.py \
 |------|------|
 | Affinity head (small molecules) | boltz (Boltz-2) |
 | Fastest, ligand support | chai |
-| Open AF3 reproduction | protenix |
+| Open AF3 reproduction | protenix (v1 base) |
+| Antibody-antigen complexes | protenix-v2 |
 
 Ranking a shortlist across more than one predictor is more reliable than trusting a
 single model.

--- a/skills/protenix/SKILL.md
+++ b/skills/protenix/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: protenix
+description: >
+  Structure prediction with Protenix, an open AlphaFold3 reproduction. Use this
+  skill when: (1) Predicting complex structures with an AF3-class model,
+  (2) Wanting an open alternative to AF3 alongside Boltz and Chai,
+  (3) Validating designed binder-target complexes.
+
+  For QC thresholds, use protein-qc. For ipSAE ranking, use ipsae.
+license: MIT
+category: design-tools
+tags: [structure-prediction, validation, alphafold3, open-source]
+biomodals_script: modal_protenix.py
+---
+
+# Protenix Structure Prediction
+
+[Protenix](https://github.com/bytedance/Protenix) is ByteDance's open PyTorch
+reproduction of AlphaFold3. It is an AF3-class complex predictor, useful next to
+`boltz` and `chai` for cross-checking designed complexes. Runnable through biomodals.
+
+## Prerequisites
+
+| Requirement | Value |
+|-------------|-------|
+| Runner | Modal (biomodals) |
+| GPU | L40S (default; `GPU` env var) |
+| Setup | See [Getting started](../../docs/getting-started.md) |
+
+## How to run
+
+```bash
+git clone https://github.com/hgbrian/biomodals && cd biomodals
+
+printf '>protein|A\nMAWTPLLLLLLSHCTGSLSQ...\n' > target.faa
+
+uv run --with modal modal run modal_protenix.py \
+  --input-faa target.faa \
+  --seeds 42 \
+  --no-use-msa
+```
+
+## Key parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--input-faa` | one required | FASTA input (or `--input-json`) |
+| `--seeds` | `42` | Comma-separated seeds |
+| `--use-msa` / `--no-use-msa` | MSA on | Pass `--no-use-msa` for single-sequence |
+| `--use-mini` | off | Switch to the smaller `protenix_mini` model |
+| `--out-dir` | `./out/protenix` | Output directory |
+
+## When to use Protenix vs Boltz vs Chai
+
+| Need | Tool |
+|------|------|
+| Affinity head (small molecules) | boltz (Boltz-2) |
+| Fastest, ligand support | chai |
+| Open AF3 reproduction | protenix |
+
+Ranking a shortlist across more than one predictor is more reliable than trusting a
+single model.
+
+## Troubleshooting
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Missing input error | No `--input-faa`/`--input-json` | Provide one |
+| Slow run | MSA enabled | Add `--no-use-msa` |
+| OOM | Large complex | Use `--use-mini` or a larger GPU |
+
+---
+
+**Next**: Rank with `ipsae`, filter with `protein-qc`.

--- a/skills/rfdiffusion/SKILL.md
+++ b/skills/rfdiffusion/SKILL.md
@@ -17,7 +17,6 @@ category: design-tools
 tags: [structure-design, diffusion, backbone, binder]
 proteinbase_slug: rfdiffusion
 proteinbase_url: https://proteinbase.com/design-methods/rfdiffusion
-biomodals_script: modal_rfdiffusion.py
 ---
 
 # RFdiffusion Backbone Generation
@@ -33,45 +32,27 @@ biomodals_script: modal_rfdiffusion.py
 
 ## How to run
 
-> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
+RFdiffusion is not in biomodals, so run it from the official RosettaCommons repo or
+its Docker image, not through Modal.
 
-### Option 1: Modal (recommended)
+### Local installation (official repo)
 ```bash
-# Clone biomodals
-git clone https://github.com/hgbrian/biomodals && cd biomodals
-
-# Basic binder design
-modal run modal_rfdiffusion.py \
-  --pdb target.pdb \
-  --contigs "A1-150/0 70-100" \
-  --hotspot "A45,A67,A89" \
-  --num-designs 100
-
-# With custom GPU/timeout
-GPU=A100 TIMEOUT=60 modal run modal_rfdiffusion.py \
-  --pdb target.pdb \
-  --contigs "A1-150/0 70-100" \
-  --num-designs 100
-```
-
-**GPU**: A10G (24GB) | **Timeout**: 30min default
-
-### Option 2: Local installation
-```bash
-# Clone and install
 git clone https://github.com/RosettaCommons/RFdiffusion.git
 cd RFdiffusion && pip install -e .
 
 # Download weights
 wget http://files.ipd.uw.edu/pub/RFdiffusion/models/Complex_base_ckpt.pt
 
-# Run inference
+# Binder design run
 python run_inference.py \
   inference.input_pdb=target.pdb \
   contigmap.contigs=[A1-150/0 70-100] \
   ppi.hotspot_res=[A45,A67,A89] \
   inference.num_designs=100
 ```
+
+A RosettaCommons-maintained Docker image is also available from the repo README.
+After backbone generation, design sequences with `proteinmpnn`.
 
 ## Config Schema (Hydra)
 

--- a/skills/rfdiffusion/SKILL.md
+++ b/skills/rfdiffusion/SKILL.md
@@ -267,6 +267,10 @@ Should I use RFdiffusion?
 
 **Expected downstream yield**: ~10-15% of backbones pass full QC after sequence design + validation.
 
+Adaptyv's own tests of these models showed an RFdiffusion + sequence-design pipeline
+costing about $0.25 per accepted design, averaged across 7 targets, among the cheapest
+of the methods tested.
+
 ---
 
 ## Verify

--- a/skills/rfdiffusion/SKILL.md
+++ b/skills/rfdiffusion/SKILL.md
@@ -33,7 +33,7 @@ biomodals_script: modal_rfdiffusion.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal (recommended)
 ```bash

--- a/skills/rfdiffusion/SKILL.md
+++ b/skills/rfdiffusion/SKILL.md
@@ -38,16 +38,23 @@ its Docker image, not through Modal.
 ### Local installation (official repo)
 ```bash
 git clone https://github.com/RosettaCommons/RFdiffusion.git
-cd RFdiffusion && pip install -e .
+cd RFdiffusion
 
-# Download weights
-wget http://files.ipd.uw.edu/pub/RFdiffusion/models/Complex_base_ckpt.pt
+# Conda env including the required NVIDIA SE(3)-Transformer
+conda env create -f env/SE3nv.yml
+conda activate SE3nv
+cd env/SE3Transformer && pip install . && cd ../..
+pip install -e .
 
-# Binder design run
-python run_inference.py \
+# Download weights (per-file hashed paths; see the repo README for the full list)
+mkdir -p models
+wget -P models http://files.ipd.uw.edu/pub/RFdiffusion/e29311f6f1bf1af907f9ef9f44b8328b/Complex_base_ckpt.pt
+
+# Binder design run; single-quote the hydra args so the shell does not split [] or ,
+./scripts/run_inference.py \
   inference.input_pdb=target.pdb \
-  contigmap.contigs=[A1-150/0 70-100] \
-  ppi.hotspot_res=[A45,A67,A89] \
+  'contigmap.contigs=[A1-150/0 70-100]' \
+  'ppi.hotspot_res=[A45,A67,A89]' \
   inference.num_designs=100
 ```
 
@@ -85,27 +92,29 @@ ppi.hotspot_res=[A45,A67,A89]
 ### Contig Syntax
 ✅ **Correct**:
 ```bash
-contigmap.contigs=[A1-150/0 70-100]  # Target fixed (/0), binder variable
+'contigmap.contigs=[A1-150/0 70-100]'  # Target fixed (/0), binder variable
 ```
+
+Single-quote the whole argument so the shell does not split on the space inside the
+brackets.
 
 ❌ **Wrong**:
 ```bash
-contigmap.contigs=[A1-150 70-100]    # Missing /0 - target will move!
-contigmap.contigs="A1-150/0 70-100"  # Quotes break parsing
-contigmap.contigs=[A1-150/0, 70-100] # Comma breaks parsing
+contigmap.contigs=[A1-150 70-100]     # Missing /0 - target will move!
+contigmap.contigs=[A1-150/0 70-100]   # Unquoted: shell splits on the space
+contigmap.contigs=[A1-150/0, 70-100]  # Extra comma changes the contig string
 ```
 
 ### Hotspot Residues
 ✅ **Correct**:
 ```bash
-ppi.hotspot_res=[A45,A67,A89]        # Chain letter + residue number
+'ppi.hotspot_res=[A45,A67,A89]'      # Chain letter + residue number, whole arg quoted
 ```
 
 ❌ **Wrong**:
 ```bash
 ppi.hotspot_res=[45,67,89]           # Missing chain letter
-ppi.hotspot_res=[A45, A67, A89]      # Spaces break parsing
-ppi.hotspot_res="A45,A67,A89"        # Quotes break parsing
+'ppi.hotspot_res=[A45, A67, A89]'    # Spaces inside the list break parsing
 ```
 
 ### Complete Parameter Reference

--- a/skills/rfdiffusion/examples/binder-walkthrough.md
+++ b/skills/rfdiffusion/examples/binder-walkthrough.md
@@ -24,14 +24,7 @@ For 1ALU chain A, good hotspots: **A42, A58, A62** (receptor binding interface)
 ## Step 3: Generate backbones
 
 ```bash
-# Using Modal
-modal run modal_rfdiffusion.py \
-  --pdb target_chainA.pdb \
-  --contigs "A1-185/0 70-90" \
-  --hotspot "A42,A58,A62" \
-  --num-designs 100
-
-# Or locally
+# RFdiffusion runs from the official repo (not biomodals)
 python run_inference.py \
   inference.input_pdb=target_chainA.pdb \
   contigmap.contigs=[A1-185/0 70-90] \

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -156,4 +156,4 @@ Modal offers $30/month in free credits - enough for:
 
 ---
 
-**Full documentation**: See [Installation Guide](../../docs/installation.md)
+**Full documentation**: See [Getting started](../../docs/getting-started.md)

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -123,8 +123,8 @@ cd biomodals
 # Design binders with BoltzGen (requires YAML config)
 modal run modal_boltzgen.py --input-yaml binder.yaml --protocol protein-anything --num-designs 50
 
-# Generate backbones with RFdiffusion
-modal run modal_rfdiffusion.py --pdb target.pdb --contigs "A1-150/0 70-100" --num-designs 100
+# Generate backbones with RFdiffusion (official repo, not biomodals)
+python run_inference.py inference.input_pdb=target.pdb contigmap.contigs=[A1-150/0 70-100] inference.num_designs=100
 
 # Validate with Chai
 modal run modal_chai1.py --input-faa designs.fasta
@@ -135,7 +135,6 @@ modal run modal_chai1.py --input-faa designs.fasta
 Set GPU with environment variable:
 
 ```bash
-GPU=A10G modal run modal_rfdiffusion.py --pdb target.pdb --contigs "A1-100/0 50-80" --num-designs 10
 GPU=L40S modal run modal_boltzgen.py --input-yaml config.yaml --num-designs 50
 GPU=A100 modal run modal_chai1.py --input-faa complex.fasta
 ```

--- a/skills/solublempnn/SKILL.md
+++ b/skills/solublempnn/SKILL.md
@@ -32,48 +32,46 @@ biomodals_script: modal_ligandmpnn.py
 > **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal (recommended)
-SolubleMPNN uses the ProteinMPNN Modal wrapper with soluble model:
+SolubleMPNN is the soluble model type within the LigandMPNN wrapper:
 ```bash
 cd biomodals
 modal run modal_ligandmpnn.py \
-  --pdb-path backbone.pdb \
-  --num-seq-per-target 16 \
-  --sampling-temp 0.1 \
-  --model-name v_48_020
+  --input-pdb backbone.pdb \
+  --params-str "--model_type soluble_mpnn --number_of_batches 16 --temperature 0.1"
 ```
 
-**GPU**: T4 (16GB) | **Timeout**: 600s default
+**GPU**: A10G default | **Timeout**: 900s default
 
 ### Option 2: Local installation
 ```bash
 git clone https://github.com/dauparas/ProteinMPNN.git
 cd ProteinMPNN
 
-# Use soluble model weights
+# The soluble weights are selected with --use_soluble_model, not a model name
 python protein_mpnn_run.py \
   --pdb_path backbone.pdb \
   --out_folder output/ \
   --num_seq_per_target 16 \
   --sampling_temp "0.1" \
-  --model_name "v_48_020"  # Soluble model
+  --use_soluble_model
 ```
 
 ## Key parameters
 
-| Parameter | Default | Range | Description |
-|-----------|---------|-------|-------------|
-| `--pdb_path` | required | path | Input structure |
-| `--num_seq_per_target` | 1 | 1-1000 | Sequences per structure |
-| `--sampling_temp` | "0.1" | "0.0001-1.0" | Temperature (string!) |
-| `--model_name` | v_48_020 | string | Soluble model variant |
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--pdb_path` | required | Input structure |
+| `--use_soluble_model` | off | Use the solubility-trained weights |
+| `--num_seq_per_target` | 1 | Sequences per structure |
+| `--sampling_temp` | "0.1" | Temperature (string) |
+| `--model_name` | v_48_020 | Noise level (0.20 A); orthogonal to solubility |
 
-## Model Variants
+## Model weights
 
-| Model | Description | Use Case |
-|-------|-------------|----------|
-| v_48_002 | Standard | General design |
-| v_48_020 | Soluble-trained | E. coli expression |
-| v_48_030 | High solubility | Difficult targets |
+`--model_name` sets the training-noise level (v_48_002 = 0.02 A, v_48_010 = 0.10 A,
+v_48_020 = 0.20 A), not a solubility tier. Solubility is a separate weight set chosen
+with `--use_soluble_model`, available for v_48_010 and v_48_020. Higher noise gives
+more sequence diversity.
 
 ## Output format
 
@@ -87,7 +85,7 @@ output/
 
 ### Successful run
 ```
-$ python protein_mpnn_run.py --pdb_path backbone.pdb --model_name v_48_020 --num_seq_per_target 8
+$ python protein_mpnn_run.py --pdb_path backbone.pdb --use_soluble_model --num_seq_per_target 8
 Loading soluble model weights (v_48_020)...
 Designing sequences for backbone.pdb
 Generated 8 sequences in 2.1 seconds
@@ -123,9 +121,8 @@ Should I use SolubleMPNN?
 │  ├─ Small molecule / ligand → Use LigandMPNN
 │  └─ Nothing / protein only → SolubleMPNN ✓
 │
-└─ Need highest solubility?
-   ├─ Yes → Use v_48_030 model
-   └─ Standard → Use v_48_020 model
+└─ Optimizing for expression?
+   └─ Add --use_soluble_model to ProteinMPNN
 ```
 
 ## Typical performance
@@ -149,7 +146,7 @@ grep -c "^>" output/seqs/*.fa  # Should match backbone_count × num_seq_per_targ
 
 ## Troubleshooting
 
-**Still insoluble**: Try v_48_030 (higher solubility bias)
+**Still insoluble**: Confirm `--use_soluble_model` is set; redesign more positions or add explicit hydrophobic-residue bias
 **Low diversity**: Increase temperature to 0.2
 **Poor folding**: Use standard ProteinMPNN and optimize later
 

--- a/skills/solublempnn/SKILL.md
+++ b/skills/solublempnn/SKILL.md
@@ -29,7 +29,7 @@ biomodals_script: modal_ligandmpnn.py
 
 ## How to run
 
-> **First time?** See [Installation Guide](../../docs/installation.md) to set up Modal and biomodals.
+> **First time?** See [Getting started](../../docs/getting-started.md) to set up Modal and biomodals.
 
 ### Option 1: Modal (recommended)
 SolubleMPNN uses the ProteinMPNN Modal wrapper with soluble model:

--- a/skills/solublempnn/SKILL.md
+++ b/skills/solublempnn/SKILL.md
@@ -35,7 +35,7 @@ biomodals_script: modal_ligandmpnn.py
 SolubleMPNN uses the ProteinMPNN Modal wrapper with soluble model:
 ```bash
 cd biomodals
-modal run modal_proteinmpnn.py \
+modal run modal_ligandmpnn.py \
   --pdb-path backbone.pdb \
   --num-seq-per-target 16 \
   --sampling-temp 0.1 \

--- a/skills/uniprot/SKILL.md
+++ b/skills/uniprot/SKILL.md
@@ -188,4 +188,4 @@ def get_sequence_variants(accession):
 
 ---
 
-**Next**: Use sequence with `esm` for embeddings or `colabfold` for structure.
+**Next**: Use sequence with `esm` for embeddings or `chai` / `boltz` for structure.


### PR DESCRIPTION
Updates the design-tool skills and QC to current SOTA, grounds binder-tool guidance in proteinbase hit-rates, adds new biomodals-backed skills, and corrects hallucinated tool references.

## New skills
- **mosaic**: multi-objective, gradient-based binder design (Escalante Bio).
- **germinal**: de novo antibody and nanobody (VHH) design via biomodals.
- **protenix**: open AlphaFold3-class structure prediction via biomodals.

## Rewritten
- **esm**: covers ESM C (embeddings/scoring) and ESMFold2 (complex prediction plus binder design by inverting ESMFold2), ESM2 kept as legacy. Points at `github.com/Biohub/esm` (MIT). ESM3 excluded (non-commercial).

## Binder-design framing (grounded in proteinbase)
- Replaced the single "BoltzGen recommended" pipeline with target-dependent guidance and a Nipah head-to-head hit-rate table from proteinbase (Mosaic 89% on 9 designs, ProteinMPNN-hybrid 25%, RFdiffusion 22%, BindCraft 7%, BoltzGen 3%).
- Mosaic is featured as the top competition performer (with a caveat that it needs tuning and that hit-rate is target-dependent); BoltzGen is kept as the cheap turnkey default, with a compute-versus-hit-rate note.

## QC (protein-qc)
- SaProtΔG stability prediction, benchmark-backed ipSAE_min ranking thresholds (Overath et al. 2025), interface BUNS and ContactMolecularSurface, sequence-liability scan, AF2Rank note.

## Correctness fixes (verified against biomodals)
- ProteinMPNN runs via `modal_ligandmpnn.py`, ESM2 via `modal_esm2_predict_masked.py`, folding via `modal_esmfold2.py`, ColabFold steps via `modal_alphafold.py`.
- RFdiffusion is documented as running from the official RosettaCommons repo, since it is not in biomodals.
- Corrected the Mosaic `build_multisample_loss` usage and the ESMFold2 / ESM C API calls.
- Also references rso, mber, iggm, esmfold2_binder_design as biomodals options.
- Boltz-2 documented as default (affinity module scoped to small molecules); dangling `installation.md` links redirected to `getting-started.md`.

24 skills total, version 2.1.0. Leaving open for review.
